### PR TITLE
Allow initializer name computation to work better with inner configs

### DIFF
--- a/modules/processor/src/main/java/processor/InitializerSpec.java
+++ b/modules/processor/src/main/java/processor/InitializerSpec.java
@@ -52,6 +52,7 @@ public class InitializerSpec {
 	private String pkg;
 	private TypeElement configurationType;
 	private ElementUtils utils;
+	private ClassName className;
 
 	public InitializerSpec(ElementUtils utils, TypeElement type) {
 		this.utils = utils;
@@ -85,10 +86,10 @@ public class InitializerSpec {
 	}
 
 	private TypeSpec createInitializer(TypeElement type) {
-		ClassName className = ClassName.get(type)
-				.peerClass(ClassName.get(type).simpleName() + "Initializer");
-		Builder builder = TypeSpec.classBuilder(className);
+		this.className = ClassName.get(ClassName.get(type).packageName(),ClassName.get(type).simpleName() + "Initializer");
+		Builder builder = TypeSpec.classBuilder(getClassName());
 		builder.addSuperinterface(SpringClassNames.INITIALIZER_TYPE);
+		builder.addModifiers(Modifier.PUBLIC);
 		builder.addMethod(createInitializer());
 		builder.addAnnotation(initializerMappingAnnotation());
 		return builder.build();
@@ -337,4 +338,9 @@ public class InitializerSpec {
 	public String toString() {
 		return "InitializerSpec:"+configurationType.toString();
 	}
+
+	public ClassName getClassName() {
+		return className;
+	}
+
 }

--- a/modules/processor/src/main/java/processor/ModuleSpec.java
+++ b/modules/processor/src/main/java/processor/ModuleSpec.java
@@ -227,7 +227,7 @@ public class ModuleSpec {
 		array[0] = first;
 		int i = 1;
 		for (InitializerSpec object : collection) {
-			array[i++] = ClassName.bestGuess(object.getInitializer().name);
+			array[i++] = object.getClassName();
 		}
 		return array;
 	}


### PR DESCRIPTION
And remember the names for later easy reference from the modules.