### PR TITLE
New processor-tests module

### DIFF
--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -18,6 +18,7 @@
 		<module>slim</module>
 		<module>library</module>
 		<module>processor</module>
+		<module>processor-tests</module>
 		<module>aspects</module>
 		<module>tests-lib</module>
 		<module>tests</module>

--- a/modules/processor-tests/pom.xml
+++ b/modules/processor-tests/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>spring-init-experiment</groupId>
+	<artifactId>processor-tests</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>2.1.0.RELEASE</version>
+	</parent>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.squareup</groupId>
+			<artifactId>javapoet</artifactId>
+			<version>1.11.1</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-function-compiler</artifactId>
+			<version>2.0.0.BUILD-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<properties>
+		<java.version>1.8</java.version>
+ 	</properties>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<proc>none</proc>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+	<repositories>
+		<repository>
+			<id>spring-libs-snapshot</id>
+			<url>http://repo.spring.io/libs-snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>spring-libs-milestone</id>
+			<url>http://repo.spring.io/libs-milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-libs-snapshot</id>
+			<url>http://repo.spring.io/libs-snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-libs-milestone</id>
+			<url>http://repo.spring.io/libs-milestone</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</pluginRepository>
+	</pluginRepositories>
+
+</project>

--- a/modules/processor-tests/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/modules/processor-tests/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+#processor.SlimConfigurationProcessor

--- a/modules/processor-tests/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/modules/processor-tests/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,0 @@
-#processor.SlimConfigurationProcessor

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CloseableFilterableJavaFileObjectIterable.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CloseableFilterableJavaFileObjectIterable.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+
+import javax.tools.JavaFileObject;
+
+import org.springframework.cloud.function.compiler.java.MemoryBasedJavaFileManager.CompilationInfoCache;
+
+/**
+ * Common superclass for iterables that need to handle closing when finished
+ * with and that need to handle possible constraints on the values that
+ * are iterated over.
+ * 
+ * @author Andy Clement
+ */
+public abstract class CloseableFilterableJavaFileObjectIterable implements Iterable<JavaFileObject> {
+
+//	private final static Logger logger = LoggerFactory.getLogger(CloseableFilterableJavaFileObjectIterable.class);
+
+	private final static boolean BOOT_PACKAGING_AWARE = true;
+	private final static String BOOT_PACKAGING_PREFIX_FOR_CLASSES = "BOOT-INF/classes/";
+
+	// If set specifies the package the iterator consumer is interested in. Only
+	// return results in this package. Will have a trailing separator to speed
+	// matching. '/' on its own represents the default package
+	protected String packageNameFilter;
+
+	// Indicates whether the consumer of the iterator wants to see classes
+	// that are in subpackages of those matching the filter.
+	protected boolean includeSubpackages;
+	
+	protected CompilationInfoCache compilationInfoCache;
+
+	public CloseableFilterableJavaFileObjectIterable(CompilationInfoCache compilationInfoCache, String packageNameFilter, boolean includeSubpackages) {
+		if (packageNameFilter!=null && packageNameFilter.contains(File.separator)) {
+			throw new IllegalArgumentException("Package name filters should use dots to separate components: "+packageNameFilter);
+		}
+		this.compilationInfoCache = compilationInfoCache;
+		// Normalize filter to forward slashes
+		this.packageNameFilter = packageNameFilter==null?null:packageNameFilter.replace('.', '/') + '/';
+		this.includeSubpackages = includeSubpackages;
+	}
+
+	/**
+	 * Used by subclasses to check values against any specified constraints.
+	 * 
+	 * @param name the name to check against the criteria
+	 * @return true if the name is a valid iterator result based on the specified criteria
+	 */
+	protected boolean accept(String name) {
+//		logger.debug("checking {} against constraints packageNameFilter={} includeSubpackages={}",name,packageNameFilter,includeSubpackages);
+		if (!name.endsWith(".class")) {
+			return false;
+		}
+		if (packageNameFilter == null) {
+			return true;
+		}
+		boolean accept;
+		// Normalize to forward slashes (some jars are producing paths with forward slashes, some with backward slashes)
+		name = name.replace('\\', '/');
+		if (packageNameFilter.length() == 1 && packageNameFilter.equals("/")) {
+			// This is the 'default package' filter representation
+			if (name.indexOf('/') == -1) {
+				accept = true;
+			} else if (BOOT_PACKAGING_AWARE) {
+					accept = name.startsWith(BOOT_PACKAGING_PREFIX_FOR_CLASSES) &&
+							name.indexOf('/',BOOT_PACKAGING_PREFIX_FOR_CLASSES.length()) == -1;
+			}
+			return accept;
+		}
+		if (includeSubpackages == true) {
+			accept = name.startsWith(packageNameFilter);
+			if (!accept && BOOT_PACKAGING_AWARE) {
+				accept = name.startsWith(BOOT_PACKAGING_PREFIX_FOR_CLASSES) &&
+						name.indexOf(packageNameFilter)==BOOT_PACKAGING_PREFIX_FOR_CLASSES.length();
+			}
+		} else {
+			accept = name.startsWith(packageNameFilter) && name.indexOf("/",packageNameFilter.length())==-1;
+			if (!accept && BOOT_PACKAGING_AWARE) {
+				accept = name.startsWith(BOOT_PACKAGING_PREFIX_FOR_CLASSES) &&
+						name.indexOf(packageNameFilter)==BOOT_PACKAGING_PREFIX_FOR_CLASSES.length() &&
+						name.indexOf("/",BOOT_PACKAGING_PREFIX_FOR_CLASSES.length()+packageNameFilter.length())==-1;
+			}
+		}
+		return accept;
+	}
+
+	abstract void close();
+
+	abstract void reset();
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompilationFailedException.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompilationFailedException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.util.List;
+
+/**
+ * @author Mark Fisher
+ */
+@SuppressWarnings("serial")
+public class CompilationFailedException extends RuntimeException {
+
+	public CompilationFailedException(List<CompilationMessage> messages) {
+		super(consolidateMessages(messages));
+	}
+
+	private static String consolidateMessages(List<CompilationMessage> messages) {
+		if (messages == null || messages.isEmpty()) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder();
+		for (CompilationMessage message : messages) {
+			sb.append(message.toString());
+		}
+		return sb.toString();
+	}
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompilationMessage.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompilationMessage.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+/**
+ * Encapsulate information produced during compilation. A message may be an error
+ * or something less serious (warning/informational). The <tt>toString()</tt> method
+ * will produce a formatted error include source context indicating the precise
+ * location of the problem.
+ * 
+ * @author Andy Clement
+ */
+public class CompilationMessage {
+	
+	private Kind kind;
+	private String message;
+	private String sourceCode;
+	private int startPosition;
+	private int endPosition;
+
+	public enum Kind {
+		ERROR, OTHER
+	};
+
+	public CompilationMessage(Kind kind, String message, String sourceCode, int startPosition, int endPosition) {
+		this.kind = kind;
+		this.message = message;
+		this.sourceCode = sourceCode;
+		this.startPosition = startPosition;
+		this.endPosition = endPosition;
+	}
+
+	/**
+	 * @return the type of message
+	 */
+	public Kind getKind() {
+		return this.kind;
+	}
+
+	/**
+	 * @return the message text
+	 */
+	public String getMessage() {
+		return this.message;
+	}
+	
+	public boolean isOther() {
+		return kind==Kind.OTHER;
+	}
+	
+	public boolean isError() {
+		return kind == Kind.ERROR;
+	}
+
+	/**
+	 * @return the source code for the file associated with the message
+	 */
+	public String getSourceCode() {
+		return this.sourceCode;
+	}
+
+	/**
+	 * @return offset from start of source file where the error begins
+	 */
+	public int getStartPosition() {
+		return this.startPosition;
+	}
+
+	/**
+	 * @return offset from start of source file where the error ends
+	 */
+	public int getEndPosition() {
+		return this.endPosition;
+	}
+
+	public String toString() {
+		StringBuilder s = new StringBuilder();
+		s.append("==========\n");
+		if (sourceCode != null) { // Cannot include source context if no source available
+			int[] lineStartEnd = getLineStartEnd(startPosition);
+			s.append(sourceCode.substring(lineStartEnd[0], lineStartEnd[1])).append("\n");
+			int col = lineStartEnd[0];
+			// When inserting the whitespace, ensure tabs in the source line are respected
+			while ((col) < startPosition) {
+				s.append(sourceCode.charAt(col++)=='\t'?"\t":" ");
+			}
+			// Want at least one ^
+			s.append("^");
+			col++;
+			while ((col++) < endPosition) {
+				s.append("^");
+			}
+			s.append("\n");
+		}
+		s.append(kind).append(":").append(message).append("\n");
+		s.append("==========\n");
+		return s.toString();
+	}
+
+	/**
+	 * For a given position in the source code this method returns a pair of int
+	 * that indicate the start and end of the line within the source code that
+	 * contain the position.
+	 * 
+	 * @param searchPos the position of interest in the source code
+	 * @return an int array of length 2 containing the start and end positions of the line
+	 */
+	private int[] getLineStartEnd(int searchPos) {
+		int previousPos = -1;
+		int pos = 0;
+		do {
+			pos = sourceCode.indexOf('\n', previousPos + 1);
+			if (searchPos < pos) {
+				return new int[] { previousPos + 1, pos };
+			}
+			previousPos = pos;
+		} while (pos != -1);
+		return new int[] { previousPos + 1, sourceCode.length() };
+	}
+	// TODO test coverage for first line/last line situations
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompilationOptions.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompilationOptions.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.function.compiler.java;
+
+/**
+ * Options that include those that apply to the call to javac but also influence the behaviour of the compiler harness (e.g. should
+ * it load classes it compiles)
+ * 
+ * @author Andy Clement
+ */
+public class CompilationOptions {
+	
+	private boolean shouldLoadClasses;
+	
+	public CompilationOptions() {
+		shouldLoadClasses= false;
+	}
+
+	public void setLoadClasses(boolean b) {
+		shouldLoadClasses = b;
+	}
+
+	public boolean shouldLoadClasses() {
+		return shouldLoadClasses;
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompilationResult.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompilationResult.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+
+/**
+ * Holder for the results of compilation. If compilation was successful the set
+ * of classes that resulted from compilation will be available. If compilation
+ * was not successful the error messages should provide information about why.
+ * Note that compilation may succeed and yet there will still be informational
+ * or warning messages collected.
+ * 
+ * @author Andy Clement
+ * @author Mark Fisher
+ */
+public class CompilationResult {
+
+	private boolean successfulCompilation;
+
+	private List<CompilationMessage> compilationMessages = new ArrayList<>();
+
+	private List<InputFileDescriptor> resources = new ArrayList<>();
+
+	private List<File> dependencies;
+
+	private List<InMemoryJavaFileObject> generatedFiles;
+
+	public CompilationResult(boolean successfulCompilation) {
+		this.successfulCompilation = successfulCompilation;
+	}
+
+	public void setDependencies(List<File> dependencies) {
+		this.dependencies = dependencies;
+	}
+
+	public List<File> getDependencies() {
+		return this.dependencies;
+	}
+
+	public boolean wasSuccessful() {
+		return successfulCompilation;
+	}
+
+	public void recordCompilationMessage(CompilationMessage message) {
+		this.compilationMessages.add(message);
+	}
+
+	public void recordCompilationMessages(List<CompilationMessage> messages) {
+		this.compilationMessages.addAll(messages);
+	}
+
+	public List<CompilationMessage> getCompilationMessages() {
+		return Collections.unmodifiableList(compilationMessages);
+	}
+
+	public String toString() {
+		return "Compilation Result: #generatedFiles="+generatedFiles.size()+" #messages="+compilationMessages.size();
+	}
+
+	public void setGeneratedFiles(List<InMemoryJavaFileObject> generatedFiles) {
+		this.generatedFiles = generatedFiles;
+	}
+
+	public List<InMemoryJavaFileObject> getGeneratedFiles() {
+		return generatedFiles;
+	}
+
+	public File dumpToTemporaryJar() {
+		File f = null;
+		try {
+			f = File.createTempFile("compiledoutput-", ".jar");
+			System.out.println("Writing generated output to " + f);
+			f.delete();
+			JarOutputStream jos = new JarOutputStream(new FileOutputStream(f));
+			Set<String> packages = new HashSet<>();
+			for (InMemoryJavaFileObject ccd : generatedFiles) {
+				// spring.factories written twice, first time no content... dig into that later
+				if (ccd.getBytes()== null) continue;
+				String entryName = ccd.getName().startsWith("/")?ccd.getName().substring(1):ccd.getName(); // remove leading slash
+				if (ccd.getKind() == Kind.CLASS) {
+//					entryName = entryName.replace(".", "/");
+				}
+				String pkg = entryName.substring(0, entryName.lastIndexOf("/") + 1);
+				packages.add(pkg);
+				JarEntry ze = new JarEntry(entryName);
+				jos.putNextEntry(ze);
+				byte[] bs = ccd.getBytes();
+				jos.write(bs, 0, bs.length);
+				jos.closeEntry();
+			}
+			for (InputFileDescriptor resource: resources) {
+				JarEntry ze = new JarEntry(resource.getName());
+				jos.putNextEntry(ze);
+				byte[] bs = resource.getContent().getBytes();
+				jos.write(bs, 0, bs.length);
+				jos.closeEntry();
+			}
+			for (String pkg : packages) {
+				JarEntry ze = new JarEntry(pkg);
+				jos.putNextEntry(ze);
+				jos.closeEntry();
+			}
+			jos.close();
+			f.deleteOnExit();
+		} catch (Throwable t) {
+			throw new IllegalStateException("Problem storing compilation result",t);
+		}
+		return f;
+	}
+
+	public void setInputResources(InputFileDescriptor[] resources) {
+		this.resources = Arrays.asList(resources);
+	}
+
+	public String getGeneratedFileContents(String name) {
+		for (InMemoryJavaFileObject generatedFile: generatedFiles) {
+			if (generatedFile.getName().equals("/"+name)) {
+				return generatedFile.getContent();
+			}
+		}
+		return null;
+	}
+
+	public boolean containsNewFile(String name) {
+		return generatedFiles.stream().anyMatch(generatedFile -> generatedFile.getName().equals("/"+name));
+	}
+
+	public void printGeneratedSources(PrintStream p) {
+		System.out.println("Sources and resources generated during compilation:");
+		for (InMemoryJavaFileObject ccd: generatedFiles) {
+			if (ccd.getKind() == JavaFileObject.Kind.CLASS) {
+				continue;
+			}
+			StringBuilder sb = new StringBuilder();
+			sb.append("=====8<===== ").append(ccd.getName()).append(" =====8<=====");
+			p.println(sb.toString());
+			p.println(ccd.getContent());
+			for (int i=0;i<sb.length();i++) p.print("=");
+			p.println();
+		}
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompiledClassDefinition.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompiledClassDefinition.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+/**
+ * Encapsulates a name with the bytes for its class definition.
+ *
+ * @author Andy Clement
+ */
+public class CompiledClassDefinition {
+
+	private byte[] bytes;
+	private String filename;
+	private String classname;
+
+	public CompiledClassDefinition(String filename, byte[] bytes) {
+		this.filename = filename;
+		this.bytes = bytes;
+		this.classname = filename;
+		if (classname.startsWith("/")) {
+			classname = classname.substring(1);
+		}
+		classname = classname.replace('/', '.').substring(0, classname.length() - 6); // strip off .class
+	}
+
+	public String getName() {
+		return filename;
+	}
+
+	public byte[] getBytes() {
+		return bytes;
+	}
+
+	@Override
+	public String toString() {
+		return "CompiledClassDefinition(name=" + getName() + ",#bytes="
+				+ getBytes().length + ")";
+	}
+
+	public String getClassName() {
+		return this.classname;
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompositeProxySelector.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/CompositeProxySelector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.aether.repository.Proxy;
+import org.eclipse.aether.repository.ProxySelector;
+import org.eclipse.aether.repository.RemoteRepository;
+
+/**
+ * Composite {@link ProxySelector}.
+ *
+ * @author Dave Syer
+ */
+public class CompositeProxySelector implements ProxySelector {
+
+	private List<ProxySelector> selectors = new ArrayList<ProxySelector>();
+
+	public CompositeProxySelector(List<ProxySelector> selectors) {
+		this.selectors = selectors;
+	}
+
+	@Override
+	public Proxy getProxy(RemoteRepository repository) {
+		for (ProxySelector selector : this.selectors) {
+			Proxy proxy = selector.getProxy(repository);
+			if (proxy != null) {
+				return proxy;
+			}
+		}
+		return null;
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/DependencyResolver.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/DependencyResolver.java
@@ -1,0 +1,491 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import javax.inject.Singleton;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.DefaultModelReader;
+import org.apache.maven.model.io.ModelReader;
+import org.apache.maven.model.locator.DefaultModelLocator;
+import org.apache.maven.model.locator.ModelLocator;
+import org.apache.maven.model.validation.DefaultModelValidator;
+import org.apache.maven.model.validation.ModelValidator;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingRequest.RepositoryMerging;
+import org.apache.maven.project.ProjectBuildingResult;
+import org.apache.maven.repository.internal.DefaultArtifactDescriptorReader;
+import org.apache.maven.repository.internal.DefaultVersionRangeResolver;
+import org.apache.maven.repository.internal.DefaultVersionResolver;
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.apache.maven.repository.internal.SnapshotMetadataGeneratorFactory;
+import org.apache.maven.repository.internal.VersionsMetadataGeneratorFactory;
+import org.apache.maven.settings.Profile;
+import org.apache.maven.settings.Repository;
+import org.codehaus.plexus.ContainerConfiguration;
+import org.codehaus.plexus.DefaultContainerConfiguration;
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.MutablePlexusContainer;
+import org.codehaus.plexus.PlexusConstants;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.classworlds.ClassWorld;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.impl.ArtifactDescriptorReader;
+import org.eclipse.aether.impl.MetadataGeneratorFactory;
+import org.eclipse.aether.impl.VersionRangeResolver;
+import org.eclipse.aether.impl.VersionResolver;
+import org.eclipse.aether.impl.guice.AetherModule;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+import org.eclipse.aether.repository.ProxySelector;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.spi.localrepo.LocalRepositoryManagerFactory;
+import org.eclipse.aether.transport.file.FileTransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.util.repository.JreProxySelector;
+import org.eclipse.sisu.inject.DefaultBeanLocator;
+import org.eclipse.sisu.plexus.ClassRealmManager;
+
+import org.springframework.core.io.Resource;
+import org.springframework.slim.processor.infra.Utils;
+import org.springframework.util.StringUtils;
+
+public class DependencyResolver {
+
+	private static DependencyResolver instance = new DependencyResolver();
+
+	private static Properties globals;
+
+	private LocalRepositoryManagerFactory localRepositoryManagerFactory;
+
+	private PlexusContainer container;
+
+	private final Object lock = new Object();
+
+	private ProjectBuilder projectBuilder;
+
+	private RepositorySystem repositorySystem;
+
+	private MavenSettings settings;
+
+	public static DependencyResolver instance() {
+		return instance;
+	}
+
+	public static void close() {
+		instance = new DependencyResolver();
+	}
+
+	private DependencyResolver() {
+	}
+
+	private void initialize() {
+		if (this.container == null) {
+			synchronized (lock) {
+				if (this.container == null) {
+					ClassWorld classWorld = new ClassWorld("plexus.core",
+							Thread.currentThread().getContextClassLoader());
+					ContainerConfiguration config = new DefaultContainerConfiguration()
+							.setClassWorld(classWorld)
+							.setRealm(classWorld.getClassRealm("plexus.core"))
+							.setClassPathScanning(PlexusConstants.SCANNING_INDEX)
+							.setAutoWiring(true).setName("maven");
+					PlexusContainer container;
+					try {
+						container = new DefaultPlexusContainer(config, new AetherModule(),
+								new DependencyResolutionModule());
+						localRepositoryManagerFactory = container
+								.lookup(LocalRepositoryManagerFactory.class);
+						container.addComponent(
+								new ClassRealmManager((MutablePlexusContainer) container,
+										new DefaultBeanLocator()),
+								ClassRealmManager.class.getName());
+						projectBuilder = container.lookup(ProjectBuilder.class);
+						repositorySystem = container.lookup(RepositorySystem.class);
+					}
+					catch (Exception e) {
+						throw new IllegalStateException("Cannot create container", e);
+					}
+					this.container = container;
+					this.settings = new MavenSettingsReader().readSettings();
+				}
+			}
+		}
+	}
+
+	public List<Dependency> dependencies(Resource resource) {
+		return dependencies(resource, new Properties());
+	}
+
+	public List<Dependency> dependencies(final Resource resource,
+			final Properties properties) {
+		initialize();
+		try {
+			ProjectBuildingRequest request = getProjectBuildingRequest(properties);
+			request.setResolveDependencies(true);
+			synchronized (DependencyResolver.class) {
+				ProjectBuildingResult result = projectBuilder
+						.build(new PropertiesModelSource(properties, resource), request);
+				DependencyResolver.globals = null;
+				DependencyResolutionResult dependencies = result
+						.getDependencyResolutionResult();
+				
+				// In our case the unresolved dependencies might be other modules in this
+				// project (in that case don't worry - we will resolve them against output folders
+				// in those modules)
+				List<Dependency> problematicDependencies = dependencies.getUnresolvedDependencies();
+				for (Iterator<Dependency> iterator = problematicDependencies.iterator(); iterator.hasNext();) {
+					Dependency dependency = iterator.next();
+					if (dependency.toString().startsWith(Utils.PROJECT+":")) {
+						iterator.remove();
+					}
+				}
+				if (!problematicDependencies.isEmpty()) {
+					StringBuilder builder = new StringBuilder();
+					for (Dependency dependency : dependencies
+							.getUnresolvedDependencies()) {
+						List<Exception> errors = dependencies
+								.getResolutionErrors(dependency);
+						for (Exception exception : errors) {
+							if (builder.length() > 0) {
+								builder.append("\n");
+							}
+							builder.append(exception.getMessage());
+						}
+					}
+					System.out.println("WIB"+runtime(dependencies.getDependencies()));
+					throw new RuntimeException(builder.toString());
+				}
+				return runtime(dependencies.getDependencies());
+			}
+		}
+		catch (ProjectBuildingException | NoLocalRepositoryManagerException e) {
+			throw new IllegalStateException("Cannot build model", e);
+		}
+	}
+
+	public File resolve(Dependency dependency) {
+		initialize();
+		return collectNonTransitive(Arrays.asList(dependency)).iterator().next()
+				.getArtifact().getFile();
+	}
+
+	private List<Dependency> runtime(List<Dependency> dependencies) {
+		List<Dependency> list = new ArrayList<>();
+		for (Dependency dependency : dependencies) {
+			if (//!"test".equals(dependency.getScope()) &&
+					 !"provided".equals(dependency.getScope())) {
+				list.add(dependency);
+			}
+		}
+		return list;
+	}
+
+	private ProjectBuildingRequest getProjectBuildingRequest(Properties properties)
+			throws NoLocalRepositoryManagerException {
+		DefaultProjectBuildingRequest projectBuildingRequest = new DefaultProjectBuildingRequest();
+		DefaultRepositorySystemSession session = createSession(properties);
+		projectBuildingRequest.setRepositoryMerging(RepositoryMerging.REQUEST_DOMINANT);
+		projectBuildingRequest.setRemoteRepositories(mavenRepositories(properties));
+		projectBuildingRequest.getRemoteRepositories()
+				.addAll(mavenRepositories(settings));
+		projectBuildingRequest.setRepositorySession(session);
+		projectBuildingRequest.setProcessPlugins(false);
+		projectBuildingRequest.setBuildStartTime(new Date());
+		projectBuildingRequest.setUserProperties(properties);
+		projectBuildingRequest.setSystemProperties(System.getProperties());
+		return projectBuildingRequest;
+	}
+
+	private Collection<? extends ArtifactRepository> mavenRepositories(
+			MavenSettings settings) {
+		List<ArtifactRepository> list = new ArrayList<>();
+		for (Profile profile : settings.getActiveProfiles()) {
+			for (Repository repository : profile.getRepositories()) {
+				addRepositoryIfMissing(list, repository.getId(), repository.getUrl(),
+						repository.getReleases() != null
+								? repository.getReleases().isEnabled() : true,
+						repository.getSnapshots() != null
+								? repository.getSnapshots().isEnabled() : false);
+			}
+		}
+		return list;
+	}
+
+	private List<ArtifactRepository> mavenRepositories(Properties properties) {
+		List<ArtifactRepository> list = new ArrayList<>();
+		addRepositoryIfMissing(list, "spring-snapshots", "https://repo.spring.io/libs-snapshot", true, true);
+		addRepositoryIfMissing(list, "central", "https://repo1.maven.org/maven2", true, false);
+		return list;
+	}
+
+	private List<RemoteRepository> aetherRepositories(Properties properties) {
+		List<RemoteRepository> list = new ArrayList<>();
+		for (ArtifactRepository input : mavenRepositories(properties)) {
+			list.add(remote(input));
+		}
+		return list;
+	}
+
+	private RemoteRepository remote(ArtifactRepository input) {
+		return new RemoteRepository.Builder(input.getId(), input.getLayout().getId(),
+				input.getUrl()).setSnapshotPolicy(policy(input.getSnapshots()))
+						.setReleasePolicy(policy(input.getReleases())).build();
+	}
+
+	private RepositoryPolicy policy(ArtifactRepositoryPolicy input) {
+		RepositoryPolicy policy = new RepositoryPolicy(input.isEnabled(),
+				RepositoryPolicy.UPDATE_POLICY_DAILY,
+				RepositoryPolicy.CHECKSUM_POLICY_WARN);
+		return policy;
+	}
+
+	private void addRepositoryIfMissing(List<ArtifactRepository> list, String id,
+			String url, boolean releases, boolean snapshots) {
+		for (ArtifactRepository repo : list) {
+			if (url.equals(repo.getUrl())) {
+				return;
+			}
+			if (id.equals(repo.getId())) {
+				return;
+			}
+		}
+		list.add(repo(id, url, releases, snapshots));
+	}
+
+	private ArtifactRepository repo(String id, String url, boolean releases,
+			boolean snapshots) {
+		MavenArtifactRepository repository = new MavenArtifactRepository();
+		repository.setLayout(new DefaultRepositoryLayout());
+		repository.setId(id);
+		repository.setUrl(url);
+		ArtifactRepositoryPolicy enabled = new ArtifactRepositoryPolicy();
+		enabled.setEnabled(true);
+		ArtifactRepositoryPolicy disabled = new ArtifactRepositoryPolicy();
+		disabled.setEnabled(false);
+		repository.setReleaseUpdatePolicy(releases ? enabled : disabled);
+		repository.setSnapshotUpdatePolicy(snapshots ? enabled : disabled);
+		return repository;
+	}
+
+	private DefaultRepositorySystemSession createSession(Properties properties)
+			throws NoLocalRepositoryManagerException {
+		DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+		LocalRepository repository = localRepository(properties);
+		session.setLocalRepositoryManager(
+				localRepositoryManagerFactory.newInstance(session, repository));
+		applySettings(session);
+		ProxySelector existing = session.getProxySelector();
+		if (existing == null || !(existing instanceof CompositeProxySelector)) {
+			JreProxySelector fallback = new JreProxySelector();
+			ProxySelector selector = existing == null ? fallback
+					: new CompositeProxySelector(Arrays.asList(existing, fallback));
+			session.setProxySelector(selector);
+		}
+		return session;
+	}
+
+	private void applySettings(DefaultRepositorySystemSession session) {
+		MavenSettingsReader.applySettings(settings, session);
+	}
+
+	private LocalRepository localRepository(Properties properties) {
+		return new LocalRepository(getM2RepoDirectory());
+	}
+
+	public Model readModel(Resource resource) {
+		return readModel(resource, new Properties());
+	}
+
+	public Model readModel(final Resource resource, final Properties properties) {
+		initialize();
+		try {
+			ProjectBuildingRequest request = getProjectBuildingRequest(properties);
+			request.setResolveDependencies(false);
+			ProjectBuildingResult result = projectBuilder
+					.build(new PropertiesModelSource(properties, resource), request);
+			return result.getProject().getModel();
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Failed to build model from effective pom",
+					e);
+		}
+	}
+
+	private File getM2RepoDirectory() {
+		return new File(getDefaultM2HomeDirectory(), "repository");
+	}
+
+	private File getDefaultM2HomeDirectory() {
+		String mavenRoot = System.getProperty("maven.home");
+		if (StringUtils.hasLength(mavenRoot)) {
+			return new File(mavenRoot);
+		}
+		return new File(System.getProperty("user.home"), ".m2");
+	}
+
+	private List<ArtifactResult> collectNonTransitive(List<Dependency> dependencies) {
+		try {
+			List<ArtifactRequest> artifactRequests = getArtifactRequests(dependencies);
+			List<ArtifactResult> result = this.repositorySystem
+					.resolveArtifacts(createSession(new Properties()), artifactRequests);
+			return result;
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException(ex);
+		}
+	}
+
+	private List<ArtifactRequest> getArtifactRequests(List<Dependency> dependencies) {
+		List<ArtifactRequest> list = new ArrayList<>();
+		for (Dependency dependency : dependencies) {
+			ArtifactRequest request = new ArtifactRequest(dependency.getArtifact(), null,
+					null);
+			request.setRepositories(aetherRepositories(new Properties()));
+			list.add(request);
+		}
+		return list;
+	}
+
+	static Properties getGlobals() {
+		return globals;
+	}
+
+	@SuppressWarnings("deprecation")
+	private static final class PropertiesModelSource
+			implements org.apache.maven.model.building.ModelSource {
+		private final Properties properties;
+
+		private final Resource resource;
+
+		private PropertiesModelSource(Properties properties, Resource resource) {
+			this.properties = properties;
+			this.resource = resource;
+		}
+
+		@Override
+		public InputStream getInputStream() throws IOException {
+			DependencyResolver.globals = properties;
+			return new BufferedInputStream(resource.getInputStream()) {
+				@Override
+				public void close() throws IOException {
+					DependencyResolver.globals = null;
+					super.close();
+				}
+			};
+		}
+
+		@Override
+		public String getLocation() {
+			return resource.getDescription();
+		}
+	}
+
+}
+
+class DependencyResolutionModule extends AbstractModule {
+
+	@Override
+	protected void configure() {
+		bind(ModelLocator.class).to(DefaultModelLocator.class).in(Singleton.class);
+		bind(ModelReader.class).to(DefaultModelReader.class).in(Singleton.class);
+		bind(ModelValidator.class).to(DefaultModelValidator.class).in(Singleton.class);
+		bind(RepositoryConnectorFactory.class).to(BasicRepositoryConnectorFactory.class)
+				.in(Singleton.class);
+		bind(ArtifactDescriptorReader.class) //
+				.to(DefaultArtifactDescriptorReader.class).in(Singleton.class);
+		bind(VersionResolver.class) //
+				.to(DefaultVersionResolver.class).in(Singleton.class);
+		bind(VersionRangeResolver.class) //
+				.to(DefaultVersionRangeResolver.class).in(Singleton.class);
+		bind(MetadataGeneratorFactory.class).annotatedWith(Names.named("snapshot")) //
+				.to(SnapshotMetadataGeneratorFactory.class).in(Singleton.class);
+		bind(MetadataGeneratorFactory.class).annotatedWith(Names.named("versions")) //
+				.to(VersionsMetadataGeneratorFactory.class).in(Singleton.class);
+		bind(TransporterFactory.class).annotatedWith(Names.named("http"))
+				.to(HttpTransporterFactory.class).in(Singleton.class);
+		bind(TransporterFactory.class).annotatedWith(Names.named("file"))
+				.to(FileTransporterFactory.class).in(Singleton.class);
+	}
+
+	@Provides
+	@Singleton
+	Set<MetadataGeneratorFactory> provideMetadataGeneratorFactories(
+			@Named("snapshot") MetadataGeneratorFactory snapshot,
+			@Named("versions") MetadataGeneratorFactory versions) {
+		Set<MetadataGeneratorFactory> factories = new HashSet<>();
+		factories.add(snapshot);
+		factories.add(versions);
+		return Collections.unmodifiableSet(factories);
+	}
+
+	@Provides
+	@Singleton
+	Set<RepositoryConnectorFactory> provideRepositoryConnectorFactories(
+			RepositoryConnectorFactory factory) {
+		return Collections.singleton(factory);
+	}
+
+	@Provides
+	@Singleton
+	Set<TransporterFactory> provideTransporterFactories(
+			@Named("file") TransporterFactory file,
+			@Named("http") TransporterFactory http) {
+		// Order is decided elsewhere (by priority)
+		Set<TransporterFactory> factories = new HashSet<TransporterFactory>();
+		factories.add(file);
+		factories.add(http);
+		return Collections.unmodifiableSet(factories);
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/DirEntryJavaFileObject.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/DirEntryJavaFileObject.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URI;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
+import javax.tools.JavaFileObject;
+
+/**
+ * A JavaFileObject that represents a file in a directory.
+ * 
+ * @author Andy Clement
+ */
+public class DirEntryJavaFileObject implements JavaFileObject {
+
+	private File file;
+	private File basedir;
+
+	public DirEntryJavaFileObject(File basedir, File file) {
+		this.basedir = basedir;
+		this.file = file;
+	}
+
+	@Override
+	public URI toUri() {
+		return file.toURI();
+	}
+
+	/**
+	 * @return the path of the file relative to the base directory, for example: a/b/c/D.class
+	 */
+	@Override
+	public String getName() {
+		String basedirPath = basedir.getPath();
+		String filePath = file.getPath();
+		return filePath.substring(basedirPath.length()+1);
+	}
+
+	@Override
+	public InputStream openInputStream() throws IOException {
+		return new FileInputStream(file);
+	}
+
+	@Override
+	public OutputStream openOutputStream() throws IOException {
+		throw new IllegalStateException("Only expected to be used for input");
+	}
+
+	@Override
+	public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
+		// It is bytecode
+		throw new UnsupportedOperationException("openReader() not supported on class file: " + getName());
+	}
+
+	@Override
+	public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+		// It is bytecode
+		throw new UnsupportedOperationException("getCharContent() not supported on class file: " + getName());
+	}
+
+	@Override
+	public Writer openWriter() throws IOException {
+		throw new IllegalStateException("only expected to be used for input");
+	}
+
+	@Override
+	public long getLastModified() {
+		return file.lastModified();
+	}
+
+	@Override
+	public boolean delete() {
+		return false; // This object is for read only access to a class
+	}
+
+	@Override
+	public Kind getKind() {
+		return Kind.CLASS;
+	}
+
+	@Override
+	public boolean isNameCompatible(String simpleName, Kind kind) {
+		if (kind != Kind.CLASS) {
+			return false;
+		}
+		String name = getName();
+		int lastSlash = name.lastIndexOf('/');
+		return name.substring(lastSlash + 1).equals(simpleName + ".class");
+	}
+
+	@Override
+	public NestingKind getNestingKind() {
+		return null;
+	}
+
+	@Override
+	public Modifier getAccessLevel() {
+		return null;
+	}
+
+	@Override
+	public int hashCode() {
+		return file.getName().hashCode()*37+basedir.getName().hashCode();
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof DirEntryJavaFileObject)) {
+			return false;
+		}
+		DirEntryJavaFileObject that = (DirEntryJavaFileObject)obj;
+		return (basedir.getName().equals(that.basedir.getName())) && (file.getName().equals(that.file.getName()));
+	}
+	
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/DirEnumeration.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/DirEnumeration.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Walks a directory hierarchy from some base directory discovering files.
+ *
+ * @author Andy Clement
+ */
+public class DirEnumeration implements Enumeration<File> {
+
+	// The starting point
+	private File basedir;
+
+	// Candidates collected so far
+	private List<File> filesToReturn;
+
+	// Places still to explore for candidates
+	private List<File> directoriesToExplore;
+
+	public DirEnumeration(File basedir) {
+		this.basedir = basedir;
+	}
+
+	private void computeValue() {
+		if (filesToReturn == null) { // Indicates we haven't started yet
+			filesToReturn = new ArrayList<>();
+			directoriesToExplore = new ArrayList<>();
+			visitDirectory(basedir);
+		}
+		if (filesToReturn.size() == 0) {
+			while (filesToReturn.size() == 0 && directoriesToExplore.size() != 0) {
+				File nextDir = directoriesToExplore.get(0);
+				directoriesToExplore.remove(0);
+				visitDirectory(nextDir);
+			}
+		}
+	}
+
+	@Override
+	public boolean hasMoreElements() {
+		computeValue();
+		return filesToReturn.size() != 0;
+	}
+
+	@Override
+	public File nextElement() {
+		computeValue();
+		if (filesToReturn.size()==0) {
+			throw new NoSuchElementException();
+		}
+		File toReturn = filesToReturn.get(0);
+		filesToReturn.remove(0);
+		return toReturn;
+	}
+
+	private void visitDirectory(File dir) {
+		File[] files = dir.listFiles();
+		if (files != null) {
+			for (File file: files) {
+				if (file.isDirectory()) {
+					directoriesToExplore.add(file);
+				} else {
+					filesToReturn.add(file);
+				}
+			}
+		}
+	}
+
+	public File getDirectory() {
+		return basedir;
+	}
+
+	/**
+	 * Return the relative path of this file to the base directory that the directory enumeration was
+	 * started for.
+	 * @param file a file discovered returned by this enumeration
+	 * @return the relative path of the file (for example: a/b/c/D.class)
+	 */
+	public String getName(File file) {
+		String basedirPath = basedir.getPath();
+		String filePath = file.getPath();
+		if (!filePath.startsWith(basedirPath)) {
+			throw new IllegalStateException("The file '"+filePath+"' is not nested below the base directory '"+basedirPath+"'");
+		}
+		return filePath.substring(basedirPath.length()+1);
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/InMemoryJavaFileObject.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/InMemoryJavaFileObject.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.CharArrayWriter;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager.Location;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A JavaFileObject that represents a source artifact created for compilation or an output
+ * artifact producing during compilation (a .class file or some other thing if an annotation
+ * processor has run). In order to be clear what it is being used for there are static factory
+ * methods that ask for specific types of file.
+ * 
+ * @author Andy Clement
+ */
+public class InMemoryJavaFileObject implements JavaFileObject {
+
+	private final static Logger logger = LoggerFactory.getLogger(InMemoryJavaFileObject.class);
+	
+	private MemoryBasedJavaFileManager fileManager;
+	private Location location;
+	private String packageName;
+	private String relativeName;
+	private FileObject sibling;
+	private String className;
+	private Kind kind;
+	
+	private byte[] content = null;
+	private long lastModifiedTime = 0;
+	private URI uri = null;
+	
+	private InMemoryJavaFileObject() {}
+	
+	public static InMemoryJavaFileObject getFileObject(MemoryBasedJavaFileManager fileManager, Location location, String packageName, String relativeName, FileObject sibling) {
+		InMemoryJavaFileObject retval = new InMemoryJavaFileObject();
+		retval.fileManager = fileManager;
+		retval.kind = Kind.OTHER;
+		retval.location = location;
+		retval.packageName = packageName;
+		retval.relativeName = relativeName;
+		retval.sibling = sibling;
+		return retval;
+	}
+	
+	public static InMemoryJavaFileObject getJavaFileObject(MemoryBasedJavaFileManager fileManager, Location location, String className, Kind kind, FileObject sibling) {
+		InMemoryJavaFileObject retval = new InMemoryJavaFileObject();
+		retval.fileManager = fileManager;
+		retval.location = location;
+		retval.className = className;
+		retval.kind = kind;
+		retval.sibling = sibling;
+		return retval;
+	}
+
+	public static InMemoryJavaFileObject getSourceJavaFileObject(String className, String content) {
+		InMemoryJavaFileObject retval = new InMemoryJavaFileObject();
+		retval.location = StandardLocation.SOURCE_PATH;
+		retval.className = className;
+		retval.kind = Kind.SOURCE;
+		retval.content = content.getBytes();
+		return retval;
+	}
+	
+	public byte[] getBytes() {
+		return content;
+	}
+
+	public String toString() {
+		return "OutputJavaFileObject: Location="+location+",className="+className+",kind="+kind+",relativeName="+relativeName+",sibling="+sibling+",packageName="+packageName;
+	}
+	
+	@Override
+	public URI toUri() {
+		// These memory based output files 'pretend' to be relative to the file system root
+		if (uri == null) {
+			String name = null;
+			if (className != null) {
+				name = className.replace('.', '/');
+			} else if (packageName !=null && packageName.length()!=0) {
+				name = packageName.replace('.', '/')+'/'+relativeName;
+			} else {
+				name = relativeName;
+			}
+			
+			String uriString = null;
+			try {
+				uriString = "file:/"+name+kind.extension;
+				uri = new URI(uriString);
+			} catch (URISyntaxException e) {
+				throw new IllegalStateException("Unexpected URISyntaxException for string '" + uriString + "'", e);
+			}
+		}
+		return uri;
+	}
+
+	@Override
+	public String getName() {
+		return toUri().getPath();
+	}
+
+	@Override
+	public InputStream openInputStream() throws IOException {
+		if (content == null) {
+			throw new FileNotFoundException();
+		}
+		logger.debug("opening input stream for {}",getName());
+		return new ByteArrayInputStream(content);
+	}
+
+	@Override
+	public OutputStream openOutputStream() throws IOException {
+		logger.debug("opening output stream for {}",getName());
+		return new ByteArrayOutputStream() {
+			@Override
+			public void close() throws IOException {
+				super.close();
+				lastModifiedTime = System.currentTimeMillis();
+				content = this.toByteArray();
+				logger.debug("output stream closed for {}: #{} bytes",getName(),content.length);
+				fileManager.recordWrite(InMemoryJavaFileObject.this);
+			}
+		};
+	}
+
+	@Override
+	public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
+		logger.debug("opening reader for {}",getName());
+		return new InputStreamReader(openInputStream(), Charset.defaultCharset());
+	}
+
+	@Override
+	public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+		if (kind==Kind.CLASS) {
+			throw new UnsupportedOperationException("getCharContent() not supported on file object of type CLASS: " + getName());
+		}
+		// Not yet supporting encodings
+		return (content==null?"":new String(content));
+	}
+
+	@Override
+	public Writer openWriter() throws IOException {
+		logger.debug("opening writer for {}",getName());
+		return new CharArrayWriter() {
+			@Override
+			public void close() {
+				lastModifiedTime = System.currentTimeMillis();
+				content = new String(toCharArray()).getBytes(); // Ignoring encoding...
+				logger.debug("writer closed for {}: #{} bytes",getName(),content.length);
+				fileManager.recordWrite(InMemoryJavaFileObject.this);
+			};
+		};
+	}
+
+	@Override
+	public long getLastModified() {
+		return lastModifiedTime;
+	}
+
+	@Override
+	public boolean delete() {
+		return false;
+	}
+
+	@Override
+	public Kind getKind() {
+		return kind;
+	}
+
+	public boolean isNameCompatible(String simpleName, Kind kind) {
+        String baseName = simpleName + kind.extension;
+        return kind.equals(getKind())
+            && (baseName.equals(toUri().getPath())
+                || toUri().getPath().endsWith("/" + baseName));
+    }
+
+	@Override
+	public NestingKind getNestingKind() {
+		return null;
+	}
+
+	@Override
+	public Modifier getAccessLevel() {
+		return null;
+	}
+
+	public String getContent() {
+		try {
+			return getCharContent(true).toString();
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to resolve content of "+this.getName(),e);
+		}
+	}
+	
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/InputFileDescriptor.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/InputFileDescriptor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+/**
+ * Representing a file that is an input to compilation - either a source or a
+ * resource file.
+ * 
+ * @author Andy Clement
+ */
+public class InputFileDescriptor {
+
+	private String name;
+	private String classname;
+	private String content;
+
+	public InputFileDescriptor(File file, String name, String classname) {
+		try {
+			content = new String(Files.readAllBytes(file.toPath()));
+		} catch (IOException e) {
+			throw new IllegalStateException("Failed to load " + file, e);
+		}
+		this.name = name;
+		this.classname = classname;
+	}
+
+	public InputFileDescriptor(String classname, String content) {
+		this.content = content;
+		this.name = classname;
+		this.classname = classname;
+	}
+
+	@Override
+	public int hashCode() {
+		return name.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return (obj instanceof InputFileDescriptor) && ((InputFileDescriptor) obj).getClassName().equals(classname);
+	}
+
+	public String getClassName() {
+		return classname;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public String toString() {
+		return "Source[" + classname + "]";
+	}
+
+	public String getPackageName() {
+		int idx = classname.lastIndexOf(".");
+		if (idx == -1) {
+			return "";
+		} else {
+			return classname.substring(0, idx);
+		}
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/IterableClasspath.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/IterableClasspath.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Stack;
+import java.util.StringTokenizer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+import javax.tools.JavaFileObject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.function.compiler.java.MemoryBasedJavaFileManager.CompilationInfoCache;
+import org.springframework.cloud.function.compiler.java.MemoryBasedJavaFileManager.CompilationInfoCache.ArchiveInfo;
+
+/**
+ * Iterable that will produce an iterator that returns classes found
+ * on a specified classpath that meet specified criteria. For jars it finds, the
+ * iterator will go into nested jars - this handles the situation with a
+ * spring boot uberjar.
+ *
+ * @author Andy Clement
+ */
+public class IterableClasspath extends CloseableFilterableJavaFileObjectIterable {
+
+	private static Logger logger = LoggerFactory.getLogger(IterableClasspath.class);
+
+	private List<File> classpathEntries = new ArrayList<>();
+
+	private List<ZipFile> openArchives = new ArrayList<>();
+
+	/**
+	 * @param compilationInfoCache cache of info that may help accelerate compilation
+	 * @param classpath a classpath of jars/directories
+	 * @param packageNameFilter an optional package name if choosing to filter (e.g. com.example)
+	 * @param includeSubpackages if true, include results in subpackages of the specified package filter
+	 */
+	IterableClasspath(CompilationInfoCache compilationInfoCache, String classpath, String packageNameFilter, boolean includeSubpackages) {
+		super(compilationInfoCache, packageNameFilter, includeSubpackages);
+		StringTokenizer tokenizer = new StringTokenizer(classpath, File.pathSeparator);
+		while (tokenizer.hasMoreElements()) {
+			String nextEntry = tokenizer.nextToken();
+			File f = new File(nextEntry);
+			if (f.exists()) {
+				// Skip iterating over archives that cannot possibly match the filter
+				if (this.packageNameFilter != null && this.packageNameFilter.length() > 0) {
+					ArchiveInfo archiveInfo = compilationInfoCache.getArchiveInfoFor(f);
+					if (archiveInfo != null && !archiveInfo.containsPackage(this.packageNameFilter, this.includeSubpackages)) {
+						continue;
+					}
+				}
+				classpathEntries.add(f);
+			} else {
+				logger.debug("path element does not exist {}",f);
+			}
+		}
+	}
+
+	public void close() {
+		for (ZipFile openArchive : openArchives) {
+			try {
+				openArchive.close();
+			} catch (IOException ioe) {
+				logger.debug("Unexpected error closing archive {}",openArchive,ioe);
+			}
+		}
+		openArchives.clear();
+	}
+
+	public Iterator<JavaFileObject> iterator() {
+		return new ClasspathEntriesIterator();
+	}
+
+	class ClasspathEntriesIterator implements Iterator<JavaFileObject> {
+		private int currentClasspathEntriesIndex = 0;
+
+		// Walking one of three possible things: directory tree, zip, or Java runtime packaged in JDK9+ form
+		private File openDirectory = null;
+		private DirEnumeration openDirectoryEnumeration = null;
+
+		private ZipFile openArchive = null;
+		private File openFile = null;
+		private ZipEntry nestedZip = null;
+		private Stack<Enumeration<? extends ZipEntry>> openArchiveEnumeration = null;
+		
+		private File openJrt;
+		private JrtFsEnumeration openJrtEnumeration = null;
+
+		private JavaFileObject nextEntry = null;
+
+		private void findNext() {
+			if (nextEntry == null) {
+				try {
+					while (openArchive!=null || openDirectory!=null || openJrt != null || currentClasspathEntriesIndex < classpathEntries.size()) {
+						if (openArchive == null && openDirectory == null && openJrt == null) {
+							// Open the next item
+							File nextFile = classpathEntries.get(currentClasspathEntriesIndex);
+							if (nextFile.isDirectory()) {
+								openDirectory = nextFile;
+								openDirectoryEnumeration = new DirEnumeration(nextFile);
+							} else if (nextFile.getName().endsWith("jrt-fs.jar")) {
+								openJrt = nextFile;
+								openJrtEnumeration = new JrtFsEnumeration(nextFile,null);
+							} else {
+								openFile = nextFile;
+								openArchive = new ZipFile(nextFile);
+								openArchives.add(openArchive);
+								openArchiveEnumeration = new Stack<Enumeration<? extends ZipEntry>>();
+								openArchiveEnumeration.push(openArchive.entries());
+							}
+							currentClasspathEntriesIndex++;
+						}
+						if (openArchiveEnumeration != null) {
+							while (!openArchiveEnumeration.isEmpty()) {
+								while (openArchiveEnumeration.peek().hasMoreElements()) {
+									ZipEntry entry = openArchiveEnumeration.peek().nextElement();
+									String entryName = entry.getName();
+									if (accept(entryName)) {
+										if (nestedZip!=null) {
+											nextEntry = new NestedZipEntryJavaFileObject(openFile, openArchive,nestedZip, entry);
+										} else {
+											nextEntry = new ZipEntryJavaFileObject(openFile, openArchive, entry);
+										}
+										return;
+									} else if (nestedZip == null && entryName.startsWith(MemoryBasedJavaFileManager.BOOT_PACKAGING_PREFIX_FOR_LIBRARIES) && entryName.endsWith(".jar")) {
+										// nested jar in uber jar
+										logger.debug("opening nested archive {}",entry.getName());
+										ZipInputStream zis = new ZipInputStream(openArchive.getInputStream(entry));
+										Enumeration<? extends ZipEntry> nestedZipEnumerator = new ZipEnumerator(zis);
+										nestedZip = entry;
+										openArchiveEnumeration.push(nestedZipEnumerator);
+									}
+								}
+								openArchiveEnumeration.pop();
+								if (nestedZip ==null) { openArchive = null; openFile = null; }
+								else nestedZip = null;
+							}
+							openArchiveEnumeration = null;
+							openArchive = null;
+							openFile = null;
+						} else if (openDirectoryEnumeration != null) {
+							while (openDirectoryEnumeration.hasMoreElements()) {
+								File entry = openDirectoryEnumeration.nextElement();
+								String name = openDirectoryEnumeration.getName(entry);
+								if (accept(name)) {
+									nextEntry = new DirEntryJavaFileObject(openDirectoryEnumeration.getDirectory(), entry);
+									return;
+								}
+							}
+							openDirectoryEnumeration = null;
+							openDirectory = null;
+						} else if (openJrtEnumeration != null) {
+							while (openJrtEnumeration.hasMoreElements()) {
+								JrtEntryJavaFileObject jrtEntry = openJrtEnumeration.nextElement();
+								String name = openJrtEnumeration.getName(jrtEntry);
+								if (accept(name)) {
+									nextEntry = jrtEntry;
+									return;
+								}
+							}
+							openJrtEnumeration = null;
+							openJrt = null;
+						}
+					}
+				} catch (IOException ioe) {
+					logger.debug("Unexpected error whilst processing classpath entries",ioe);
+				}
+			}
+		}
+
+		public boolean hasNext() {
+			findNext();
+			return nextEntry != null;
+		}
+
+		public JavaFileObject next() {
+			findNext();
+			if (nextEntry == null) {
+				throw new NoSuchElementException();
+			}
+			JavaFileObject retval = nextEntry;
+			nextEntry = null;
+			return retval;
+		}
+
+	}
+
+	static class ZipEnumerator implements Enumeration<ZipEntry>{
+
+		private ZipInputStream zis;
+		private ZipEntry nextEntry = null;
+
+		public ZipEnumerator(ZipInputStream zis) {
+			this.zis = zis;
+		}
+
+		@Override
+		public boolean hasMoreElements() {
+			try {
+				nextEntry = zis.getNextEntry();
+			} catch (IOException ioe) {
+				nextEntry=null;
+			}
+			return nextEntry!=null;
+		}
+
+		@Override
+		public ZipEntry nextElement() {
+			ZipEntry retval = nextEntry;
+			nextEntry = null;
+			return retval;
+		}
+
+	}
+
+	public void reset() {
+		close();
+	}
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/IterableJrtModule.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/IterableJrtModule.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2018 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import javax.tools.JavaFileObject;
+
+import org.springframework.cloud.function.compiler.java.MemoryBasedJavaFileManager.CompilationInfoCache;
+
+/**
+ * Iterable that will produce an iterator that returns classes found
+ * in a specific module tree within the Java runtime image that exists in
+ * Java 9 and later.
+ * 
+ * @author Andy Clement
+ */
+public class IterableJrtModule extends CloseableFilterableJavaFileObjectIterable {
+
+//	private static Logger logger = LoggerFactory.getLogger(IterableJrtModule.class);
+
+	private Path moduleRootPath;
+	
+	Map<String, JrtFsEnumeration> walkers = new HashMap<>();
+
+	/**
+	 * @param compilationInfoCache cache of info that may help accelerate compilation
+	 * @param moduleRootPath path to the base of the relevant module within the JRT image
+	 * @param packageNameFilter an optional package name if choosing to filter (e.g. com.example)
+	 * @param includeSubpackages if true, include results in subpackages of the specified package filter
+	 */
+	public IterableJrtModule(CompilationInfoCache compilationInfoCache, Path moduleRootPath, String packageNameFilter,
+			boolean includeSubpackages) {
+		super(compilationInfoCache, packageNameFilter, includeSubpackages);
+		this.moduleRootPath = moduleRootPath;
+	}
+
+	public Iterator<JavaFileObject> iterator() {
+		JrtFsEnumeration jrtFsWalker = walkers.get(moduleRootPath.toString());
+		if (jrtFsWalker == null) {
+			jrtFsWalker = new JrtFsEnumeration(null, moduleRootPath);
+			walkers.put(moduleRootPath.toString(), jrtFsWalker);
+		}
+		jrtFsWalker.reset();
+		return new IteratorOverJrtFsEnumeration(jrtFsWalker);
+	}
+	
+	class IteratorOverJrtFsEnumeration implements Iterator<JavaFileObject> {
+
+		private JavaFileObject nextEntry = null;
+		
+		private JrtFsEnumeration jrtEnumeration;
+
+		public IteratorOverJrtFsEnumeration(JrtFsEnumeration jrtFsWalker) {
+			this.jrtEnumeration = jrtFsWalker;
+		}
+
+		private void findNext() {
+			if (nextEntry == null) {
+				while (jrtEnumeration.hasMoreElements()) {
+					JrtEntryJavaFileObject jrtEntry = jrtEnumeration.nextElement();
+					String name = jrtEnumeration.getName(jrtEntry);
+					if (accept(name)) {
+						nextEntry = jrtEntry;
+						return;
+					}
+				}
+			}
+		}
+
+		public boolean hasNext() {
+			findNext();
+			return nextEntry != null;
+		}
+
+		public JavaFileObject next() {
+			findNext();
+			if (nextEntry == null) {
+				throw new NoSuchElementException();
+			}
+			JavaFileObject retval = nextEntry;
+			nextEntry = null;
+			return retval;
+		}
+	}
+
+	public void close() {
+	}
+
+	public void reset() {
+		close();
+	}
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/JrtEntryJavaFileObject.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/JrtEntryJavaFileObject.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2018 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
+import javax.tools.JavaFileObject;
+
+/**
+ * A JavaFileObject that represents a class from the Java runtime as packaged in Java 9 and later.
+ * 
+ * @author Andy Clement
+ */
+public class JrtEntryJavaFileObject implements JavaFileObject {
+
+	private String pathToClassString;
+	private Path path;
+
+	/**
+	 * @param path entry in the Java runtime filesystem, for example '/modules/java.base/java/lang/Object.class'
+	 */
+	public JrtEntryJavaFileObject(Path path) {
+		this.pathToClassString = path.subpath(2, path.getNameCount()).toString(); // e.g. java/lang/Object.class
+		this.path = path;
+	}
+
+	@Override
+	public URI toUri() {
+		return path.toUri();
+	}
+
+	/**
+	 * @return the path of the file relative to the base directory, for example: a/b/c/D.class
+	 */
+	@Override
+	public String getName() {
+		return pathToClassString;
+	}
+
+	@Override
+	public InputStream openInputStream() throws IOException {
+		byte[] bytes = Files.readAllBytes(path);
+		return new ByteArrayInputStream(bytes);
+	}
+
+	@Override
+	public OutputStream openOutputStream() throws IOException {
+		throw new IllegalStateException("Only expected to be used for input");
+	}
+
+	@Override
+	public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
+		// It is bytecode
+		throw new UnsupportedOperationException("openReader() not supported on class file: " + getName());
+	}
+
+	@Override
+	public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+		// It is bytecode
+		throw new UnsupportedOperationException("getCharContent() not supported on class file: " + getName());
+	}
+
+	@Override
+	public Writer openWriter() throws IOException {
+		throw new IllegalStateException("only expected to be used for input");
+	}
+
+	@Override
+	public long getLastModified() {
+		try {
+			return Files.getLastModifiedTime(path).toMillis();
+		} catch (IOException ioe) {
+			throw new RuntimeException("Unable to determine last modified time of "+pathToClassString, ioe);
+		}
+	}
+
+	@Override
+	public boolean delete() {
+		return false; // This object is for read only access to a class
+	}
+
+	@Override
+	public Kind getKind() {
+		return Kind.CLASS;
+	}
+
+	@Override
+	public boolean isNameCompatible(String simpleName, Kind kind) {
+		if (kind != Kind.CLASS) {
+			return false;
+		}
+		String name = getName();
+		int lastSlash = name.lastIndexOf('/');
+		return name.substring(lastSlash + 1).equals(simpleName + ".class");
+	}
+
+	@Override
+	public NestingKind getNestingKind() {
+		return null;
+	}
+
+	@Override
+	public Modifier getAccessLevel() {
+		return null;
+	}
+
+	@Override
+	public int hashCode() {
+		return getName().hashCode();
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof JrtEntryJavaFileObject)) {
+			return false;
+		}
+		JrtEntryJavaFileObject that = (JrtEntryJavaFileObject)obj;
+		return (getName().equals(that.getName()));
+	}
+
+	public String getPathToClassString() {
+		return pathToClassString;
+	}
+	
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/JrtFsEnumeration.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/JrtFsEnumeration.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Walks a JrtFS treating it like a directory (to avoid overcomplicating the walking
+ * logic in IterableClasspath)
+ * 
+ * @author Andy Clement
+ */
+public class JrtFsEnumeration implements Enumeration<JrtEntryJavaFileObject> {
+	
+//	private final static Logger logger = LoggerFactory.getLogger(JrtFsEnumeration.class);
+
+	private static URI JRT_URI = URI.create("jrt:/"); //$NON-NLS-1$
+	
+	private final static FileSystem fs = FileSystems.getFileSystem(JRT_URI);
+	
+	private Path pathWithinJrt;
+	
+	private List<JrtEntryJavaFileObject> jfos = new ArrayList<>();
+	
+	private Integer counter = 0;
+	
+	private Boolean initialized = false;
+
+	public JrtFsEnumeration(File jrtFsFile, Path pathWithinJrt) {
+		this.pathWithinJrt = pathWithinJrt;
+		ensureInitialized();
+	}
+
+	class FileCacheBuilderVisitor extends SimpleFileVisitor<Path> {
+		@Override
+		public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+			int fnc = file.getNameCount();
+			if (fnc >= 3 && file.toString().endsWith(".class")) { // There is a preceeding module name - e.g. /modules/java.base/java/lang/Object.class
+				// file.subpath(2, fnc); // e.g. java/lang/Object.class
+				jfos.add(new JrtEntryJavaFileObject(file));
+			}
+			return FileVisitResult.CONTINUE;
+		}
+	}
+	
+	private void ensureInitialized() {
+		synchronized (initialized) {
+			if (initialized) {
+				return;
+			}
+			FileCacheBuilderVisitor visitor = new FileCacheBuilderVisitor();
+			if (pathWithinJrt != null) {
+				try {
+					Files.walkFileTree(pathWithinJrt, visitor);
+					// System.out.println("JrtFs enumeration for '"+pathWithinJrt+"' with #"+jfos.size()+" entries");
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			} else {
+				Iterable<java.nio.file.Path> roots = fs.getRootDirectories();
+				try {
+					for (java.nio.file.Path path : roots) {
+						Files.walkFileTree(path, visitor);
+					}
+					// System.out.println("JrtFs enumeration initialized with #"+jfos.size()+" entries");
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+			initialized = true;
+		}
+	}
+
+	@Override
+	public boolean hasMoreElements() {
+		return counter < jfos.size();
+	}
+
+	@Override
+	public JrtEntryJavaFileObject nextElement() {
+		if (counter>=jfos.size()) {
+			throw new NoSuchElementException();
+		}
+		JrtEntryJavaFileObject toReturn = jfos.get(counter++);
+		return toReturn;
+	}
+
+	/**
+	 * Return the relative path of this file to the base directory that the directory enumeration was
+	 * started for.
+	 * @param file a file discovered returned by this enumeration 
+	 * @return the relative path of the file (for example: a/b/c/D.class)
+	 */
+	public String getName(JrtEntryJavaFileObject file) {
+		return file.getPathToClassString();
+	}
+	
+	public void reset() {
+		counter = 0;
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/MavenSettings.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/MavenSettings.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.model.ActivationFile;
+import org.apache.maven.model.ActivationOS;
+import org.apache.maven.model.ActivationProperty;
+import org.apache.maven.model.building.ModelProblemCollector;
+import org.apache.maven.model.building.ModelProblemCollectorRequest;
+import org.apache.maven.model.path.DefaultPathTranslator;
+import org.apache.maven.model.profile.DefaultProfileSelector;
+import org.apache.maven.model.profile.ProfileActivationContext;
+import org.apache.maven.model.profile.activation.FileProfileActivator;
+import org.apache.maven.model.profile.activation.JdkVersionProfileActivator;
+import org.apache.maven.model.profile.activation.OperatingSystemProfileActivator;
+import org.apache.maven.model.profile.activation.PropertyProfileActivator;
+import org.apache.maven.settings.Activation;
+import org.apache.maven.settings.Mirror;
+import org.apache.maven.settings.Profile;
+import org.apache.maven.settings.Proxy;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.AuthenticationSelector;
+import org.eclipse.aether.repository.MirrorSelector;
+import org.eclipse.aether.repository.ProxySelector;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+import org.eclipse.aether.util.repository.ConservativeAuthenticationSelector;
+import org.eclipse.aether.util.repository.DefaultAuthenticationSelector;
+import org.eclipse.aether.util.repository.DefaultMirrorSelector;
+import org.eclipse.aether.util.repository.DefaultProxySelector;
+
+/**
+ * An encapsulation of settings read from a user's Maven settings.xml.
+ *
+ * @author Andy Wilkinson
+ * @see MavenSettingsReader
+ */
+public class MavenSettings {
+
+	private final boolean offline;
+
+	private final MirrorSelector mirrorSelector;
+
+	private final AuthenticationSelector authenticationSelector;
+
+	private final ProxySelector proxySelector;
+
+	private final String localRepository;
+
+	private final List<Profile> activeProfiles;
+
+	/**
+	 * Create a new {@link MavenSettings} instance.
+	 * @param settings the source settings
+	 * @param decryptedSettings the decrypted settings
+	 */
+	public MavenSettings(Settings settings, SettingsDecryptionResult decryptedSettings) {
+		this.offline = settings.isOffline();
+		this.mirrorSelector = createMirrorSelector(settings);
+		this.authenticationSelector = createAuthenticationSelector(decryptedSettings);
+		this.proxySelector = createProxySelector(decryptedSettings);
+		this.localRepository = settings.getLocalRepository();
+		this.activeProfiles = determineActiveProfiles(settings);
+	}
+
+	private MirrorSelector createMirrorSelector(Settings settings) {
+		DefaultMirrorSelector selector = new DefaultMirrorSelector();
+		for (Mirror mirror : settings.getMirrors()) {
+			selector.add(mirror.getId(), mirror.getUrl(), mirror.getLayout(), false,
+					mirror.getMirrorOf(), mirror.getMirrorOfLayouts());
+		}
+		return selector;
+	}
+
+	private AuthenticationSelector createAuthenticationSelector(
+			SettingsDecryptionResult decryptedSettings) {
+		DefaultAuthenticationSelector selector = new DefaultAuthenticationSelector();
+		for (Server server : decryptedSettings.getServers()) {
+			AuthenticationBuilder auth = new AuthenticationBuilder();
+			auth.addUsername(server.getUsername()).addPassword(server.getPassword());
+			auth.addPrivateKey(server.getPrivateKey(), server.getPassphrase());
+			selector.add(server.getId(), auth.build());
+		}
+		return new ConservativeAuthenticationSelector(selector);
+	}
+
+	private ProxySelector createProxySelector(
+			SettingsDecryptionResult decryptedSettings) {
+		DefaultProxySelector selector = new DefaultProxySelector();
+		for (Proxy proxy : decryptedSettings.getProxies()) {
+			Authentication authentication = new AuthenticationBuilder()
+					.addUsername(proxy.getUsername()).addPassword(proxy.getPassword())
+					.build();
+			selector.add(
+					new org.eclipse.aether.repository.Proxy(proxy.getProtocol(),
+							proxy.getHost(), proxy.getPort(), authentication),
+					proxy.getNonProxyHosts());
+		}
+		return selector;
+	}
+
+	private List<Profile> determineActiveProfiles(Settings settings) {
+		SpringBootCliModelProblemCollector problemCollector = new SpringBootCliModelProblemCollector();
+		List<org.apache.maven.model.Profile> activeModelProfiles = createProfileSelector()
+				.getActiveProfiles(createModelProfiles(settings.getProfiles()),
+						new SpringBootCliProfileActivationContext(
+								settings.getActiveProfiles()),
+						problemCollector);
+		if (!problemCollector.getProblems().isEmpty()) {
+			throw new IllegalStateException(createFailureMessage(problemCollector));
+		}
+		List<Profile> activeProfiles = new ArrayList<Profile>();
+		Map<String, Profile> profiles = settings.getProfilesAsMap();
+		for (org.apache.maven.model.Profile modelProfile : activeModelProfiles) {
+			activeProfiles.add(profiles.get(modelProfile.getId()));
+		}
+		return activeProfiles;
+	}
+
+	private String createFailureMessage(
+			SpringBootCliModelProblemCollector problemCollector) {
+		StringWriter message = new StringWriter();
+		PrintWriter printer = new PrintWriter(message);
+		printer.println("Failed to determine active profiles:");
+		for (ModelProblemCollectorRequest problem : problemCollector.getProblems()) {
+			printer.println("    " + problem.getMessage() + (problem.getLocation() != null
+					? " at " + problem.getLocation() : ""));
+			if (problem.getException() != null) {
+				printer.println(indentStackTrace(problem.getException(), "        "));
+			}
+		}
+		return message.toString();
+	}
+
+	private String indentStackTrace(Exception ex, String indent) {
+		return indentLines(printStackTrace(ex), indent);
+	}
+
+	private String printStackTrace(Exception ex) {
+		StringWriter stackTrace = new StringWriter();
+		PrintWriter printer = new PrintWriter(stackTrace);
+		ex.printStackTrace(printer);
+		return stackTrace.toString();
+	}
+
+	private String indentLines(String input, String indent) {
+		StringWriter indented = new StringWriter();
+		PrintWriter writer = new PrintWriter(indented);
+		String line;
+		BufferedReader reader = new BufferedReader(new StringReader(input));
+		try {
+			while ((line = reader.readLine()) != null) {
+				writer.println(indent + line);
+			}
+		}
+		catch (IOException ex) {
+			return input;
+		}
+		return indented.toString();
+	}
+
+	private DefaultProfileSelector createProfileSelector() {
+		DefaultProfileSelector selector = new DefaultProfileSelector();
+
+		selector.addProfileActivator(new FileProfileActivator()
+				.setPathTranslator(new DefaultPathTranslator()));
+		selector.addProfileActivator(new JdkVersionProfileActivator());
+		selector.addProfileActivator(new PropertyProfileActivator());
+		selector.addProfileActivator(new OperatingSystemProfileActivator());
+		return selector;
+	}
+
+	private List<org.apache.maven.model.Profile> createModelProfiles(
+			List<Profile> profiles) {
+		List<org.apache.maven.model.Profile> modelProfiles = new ArrayList<org.apache.maven.model.Profile>();
+		for (Profile profile : profiles) {
+			org.apache.maven.model.Profile modelProfile = new org.apache.maven.model.Profile();
+			modelProfile.setId(profile.getId());
+			if (profile.getActivation() != null) {
+				modelProfile
+						.setActivation(createModelActivation(profile.getActivation()));
+			}
+			modelProfiles.add(modelProfile);
+		}
+		return modelProfiles;
+	}
+
+	private org.apache.maven.model.Activation createModelActivation(
+			Activation activation) {
+		org.apache.maven.model.Activation modelActivation = new org.apache.maven.model.Activation();
+		modelActivation.setActiveByDefault(activation.isActiveByDefault());
+		if (activation.getFile() != null) {
+			ActivationFile activationFile = new ActivationFile();
+			activationFile.setExists(activation.getFile().getExists());
+			activationFile.setMissing(activation.getFile().getMissing());
+			modelActivation.setFile(activationFile);
+		}
+		modelActivation.setJdk(activation.getJdk());
+		if (activation.getOs() != null) {
+			ActivationOS os = new ActivationOS();
+			os.setArch(activation.getOs().getArch());
+			os.setFamily(activation.getOs().getFamily());
+			os.setName(activation.getOs().getName());
+			os.setVersion(activation.getOs().getVersion());
+			modelActivation.setOs(os);
+		}
+		if (activation.getProperty() != null) {
+			ActivationProperty property = new ActivationProperty();
+			property.setName(activation.getProperty().getName());
+			property.setValue(activation.getProperty().getValue());
+			modelActivation.setProperty(property);
+		}
+		return modelActivation;
+	}
+
+	public boolean getOffline() {
+		return this.offline;
+	}
+
+	public MirrorSelector getMirrorSelector() {
+		return this.mirrorSelector;
+	}
+
+	public AuthenticationSelector getAuthenticationSelector() {
+		return this.authenticationSelector;
+	}
+
+	public ProxySelector getProxySelector() {
+		return this.proxySelector;
+	}
+
+	public String getLocalRepository() {
+		return this.localRepository;
+	}
+
+	public List<Profile> getActiveProfiles() {
+		return this.activeProfiles;
+	}
+
+	private static final class SpringBootCliProfileActivationContext
+			implements ProfileActivationContext {
+
+		private final List<String> activeProfiles;
+
+		SpringBootCliProfileActivationContext(List<String> activeProfiles) {
+			this.activeProfiles = activeProfiles;
+		}
+
+		@Override
+		public List<String> getActiveProfileIds() {
+			return this.activeProfiles;
+		}
+
+		@Override
+		public List<String> getInactiveProfileIds() {
+			return Collections.emptyList();
+		}
+
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		@Override
+		public Map<String, String> getSystemProperties() {
+			return (Map) System.getProperties();
+		}
+
+		@Override
+		public Map<String, String> getUserProperties() {
+			return Collections.emptyMap();
+		}
+
+		@Override
+		public File getProjectDirectory() {
+			return new File(".");
+		}
+
+		@Override
+		public Map<String, String> getProjectProperties() {
+			return Collections.emptyMap();
+		}
+
+	}
+
+	private static final class SpringBootCliModelProblemCollector
+			implements ModelProblemCollector {
+
+		private final List<ModelProblemCollectorRequest> problems = new ArrayList<ModelProblemCollectorRequest>();
+
+		@Override
+		public void add(ModelProblemCollectorRequest req) {
+			this.problems.add(req);
+		}
+
+		List<ModelProblemCollectorRequest> getProblems() {
+			return this.problems;
+		}
+
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/MavenSettingsReader.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/MavenSettingsReader.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.lang.reflect.Field;
+
+import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
+import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
+import org.apache.maven.settings.building.SettingsBuildingException;
+import org.apache.maven.settings.building.SettingsBuildingRequest;
+import org.apache.maven.settings.crypto.DefaultSettingsDecrypter;
+import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.internal.impl.SimpleLocalRepositoryManagerFactory;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.NoLocalRepositoryManagerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.plexus.components.cipher.DefaultPlexusCipher;
+import org.sonatype.plexus.components.cipher.PlexusCipherException;
+import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
+
+/**
+ * {@code MavenSettingsReader} reads settings from a user's Maven settings.xml file,
+ * decrypting them if necessary using settings-security.xml.
+ *
+ * @author Andy Wilkinson
+ */
+public class MavenSettingsReader {
+
+	private static final Logger log = LoggerFactory.getLogger(MavenSettingsReader.class);
+
+	private final String homeDir;
+
+	public MavenSettingsReader() {
+		this(System.getProperty("user.home"));
+	}
+
+	public MavenSettingsReader(String homeDir) {
+		this.homeDir = homeDir;
+	}
+
+	public MavenSettings readSettings() {
+		Settings settings = loadSettings();
+		SettingsDecryptionResult decrypted = decryptSettings(settings);
+		if (!decrypted.getProblems().isEmpty()) {
+			log.error(
+					"Maven settings decryption failed. Some Maven repositories may be inaccessible");
+			// Continue - the encrypted credentials may not be used
+		}
+		return new MavenSettings(settings, decrypted);
+	}
+
+	public static void applySettings(MavenSettings settings,
+			DefaultRepositorySystemSession session) {
+		if (settings.getLocalRepository() != null) {
+			try {
+				session.setLocalRepositoryManager(
+						new SimpleLocalRepositoryManagerFactory().newInstance(session,
+								new LocalRepository(settings.getLocalRepository())));
+			}
+			catch (NoLocalRepositoryManagerException e) {
+				throw new IllegalStateException(
+						"Cannot set local repository to " + settings.getLocalRepository(),
+						e);
+			}
+		}
+		session.setOffline(settings.getOffline());
+		session.setMirrorSelector(settings.getMirrorSelector());
+		session.setAuthenticationSelector(settings.getAuthenticationSelector());
+		session.setProxySelector(settings.getProxySelector());
+	}
+
+	private Settings loadSettings() {
+		File settingsFile = new File(this.homeDir, ".m2/settings.xml");
+		if (settingsFile.exists()) {
+			log.debug("Reading settings from: " + settingsFile);
+		}
+		else {
+			log.debug("No settings found at: " + settingsFile);
+		}
+		SettingsBuildingRequest request = new DefaultSettingsBuildingRequest();
+		request.setUserSettingsFile(settingsFile);
+		request.setSystemProperties(System.getProperties());
+		try {
+			return new DefaultSettingsBuilderFactory().newInstance().build(request)
+					.getEffectiveSettings();
+		}
+		catch (SettingsBuildingException ex) {
+			throw new IllegalStateException(
+					"Failed to build settings from " + settingsFile, ex);
+		}
+	}
+
+	private SettingsDecryptionResult decryptSettings(Settings settings) {
+		DefaultSettingsDecryptionRequest request = new DefaultSettingsDecryptionRequest(
+				settings);
+
+		return createSettingsDecrypter().decrypt(request);
+	}
+
+	private SettingsDecrypter createSettingsDecrypter() {
+		SettingsDecrypter settingsDecrypter = new DefaultSettingsDecrypter();
+		setField(DefaultSettingsDecrypter.class, "securityDispatcher", settingsDecrypter,
+				new SpringBootSecDispatcher());
+		return settingsDecrypter;
+	}
+
+	private void setField(Class<?> sourceClass, String fieldName, Object target,
+			Object value) {
+		try {
+			Field field = sourceClass.getDeclaredField(fieldName);
+			field.setAccessible(true);
+			field.set(target, value);
+		}
+		catch (Exception ex) {
+			throw new IllegalStateException(
+					"Failed to set field '" + fieldName + "' on '" + target + "'", ex);
+		}
+	}
+
+	private class SpringBootSecDispatcher extends DefaultSecDispatcher {
+
+		private static final String SECURITY_XML = ".m2/settings-security.xml";
+
+		SpringBootSecDispatcher() {
+			File file = new File(MavenSettingsReader.this.homeDir, SECURITY_XML);
+			this._configurationFile = file.getAbsolutePath();
+			try {
+				this._cipher = new DefaultPlexusCipher();
+			}
+			catch (PlexusCipherException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/MemoryBasedJavaFileManager.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/MemoryBasedJavaFileManager.java
@@ -1,0 +1,730 @@
+/*
+ * Copyright 2016-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+import javax.tools.FileObject;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardLocation;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.function.compiler.java.IterableClasspath.ZipEnumerator;
+
+/**
+ * A file manager that serves source code from in memory and ensures output results are
+ * kept in memory rather than being flushed out to disk. The JavaFileManager is also used
+ * as a lookup mechanism for resolving types.
+ *
+ * @author Andy Clement
+ * @author Oleg Zhurakousky
+ */
+public class MemoryBasedJavaFileManager implements JavaFileManager {
+
+	final static String BOOT_PACKAGING_PREFIX_FOR_CLASSES = "BOOT-INF/classes/";
+
+	final static String BOOT_PACKAGING_PREFIX_FOR_LIBRARIES = "BOOT-INF/lib/";
+
+	private static Logger logger = LoggerFactory
+			.getLogger(MemoryBasedJavaFileManager.class);
+
+	private List<InMemoryJavaFileObject> outputFiles = new ArrayList<>();
+
+	private Map<String, File> resolvedAdditionalDependencies = new LinkedHashMap<>();
+
+	private String platformClasspath;
+
+	private String classpath;
+
+	private CompilationInfoCache compilationInfoCache;
+
+	private Map<Key, CloseableFilterableJavaFileObjectIterable> iterables = new HashMap<>();
+
+	private String processorPath;
+
+	public MemoryBasedJavaFileManager() {
+		compilationInfoCache = new CompilationInfoCache();
+	}
+	
+	public void reset() {
+		this.outputFiles.clear();
+	}
+
+	@Override
+	public int isSupportedOption(String option) {
+		logger.info("isSupportedOption({})", option);
+		if (option.equals("-processorpath")) {
+			return 0;
+		}
+		return -1; // Not yet supporting options
+	}
+
+	@Override
+	public ClassLoader getClassLoader(Location location) {
+		logger.debug("getClassLoader({})", location);
+		if (location == StandardLocation.ANNOTATION_PROCESSOR_PATH && processorPath != null) {
+			logger.debug("building classloader for processor path {}", processorPath);
+			try {
+				return new URLClassLoader(new URL[] {new File(processorPath).toURI().toURL()},this.getClass().getClassLoader());
+			} catch (MalformedURLException mue) {
+				logger.info("Bad URL for "+processorPath);
+			}
+		}
+		// Do not simply return the context classloader as it may get closed and then
+		// be unusable for loading any further classes
+		return null; // Do not currently need to load plugins
+	}
+
+	// Holds information that may help speed up compilation
+	static class CompilationInfoCache {
+
+		private Map<File, ArchiveInfo> archivePackageCache;
+
+		static class ArchiveInfo {
+
+			// The packages identified in a particular archive
+			private List<String> packageNames;
+
+			private boolean isBootJar = false;
+
+			public ArchiveInfo(List<String> packageNames, boolean isBootJar) {
+				this.packageNames = packageNames;
+				Collections.sort(this.packageNames);
+				this.isBootJar = isBootJar;
+			}
+
+			public List<String> getPackageNames() {
+				return packageNames;
+			}
+
+			public boolean isBootJar() {
+				return isBootJar;
+			}
+
+			public boolean containsPackage(String packageName, boolean subpackageMatchesAllowed) {
+				if (subpackageMatchesAllowed) {
+					for (String candidatePackageName: packageNames) {
+						if (candidatePackageName.startsWith(packageName)) {
+							return true;
+						}
+					}
+					return false;
+				} else {
+					// Must be an exact match, fast binary search:
+					int pos = Collections.binarySearch(packageNames, packageName);
+					return  (pos >= 0);
+				}
+			}
+		}
+
+		ArchiveInfo getArchiveInfoFor(File archive) {
+			if (!archive.isFile() || !(archive.getName().endsWith(".zip") || archive.getName().endsWith(".jar"))) {
+				// it is not an archive
+				return null;
+			}
+			if (archivePackageCache == null) {
+				archivePackageCache = new HashMap<>();
+			}
+			try {
+				ArchiveInfo result = archivePackageCache.get(archive);
+				if (result == null) {
+					result = buildArchiveInfo(archive);
+					archivePackageCache.put(archive, result);
+				}
+				return result;
+			} catch (Exception e) {
+				throw new IllegalStateException("Unexpected problem caching entries from "+archive.getName(), e);
+			}
+		}
+
+		private boolean packageCacheInitialized = false;
+		private Map<String, Path> packageCache = new HashMap<String, Path>();
+		private ArchiveInfo moduleArchiveInfo;
+
+		private class PackageCacheBuilderVisitor extends SimpleFileVisitor<Path> {
+			
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				if (file.getNameCount() > 3 && file.toString().endsWith(".class")) {
+					int fnc = file.getNameCount();
+					if (fnc > 3) { // There is a package name - e.g. /modules/java.base/java/lang/Object.class
+						Path packagePath = file.subpath(2, fnc-1); // e.g. java/lang
+						String packagePathString = packagePath.toString()+"/";
+						packageCache.put(packagePathString, file.subpath(0, fnc-1)); // java/lang -> /modules/java.base/java/lang
+					}
+				}
+				return FileVisitResult.CONTINUE;
+			}
+		}
+		
+		private synchronized ArchiveInfo buildPackageMap() {
+			if (!packageCacheInitialized) {
+				packageCacheInitialized = true;
+				Iterable<java.nio.file.Path> roots = getJrtFs().getRootDirectories();
+				PackageCacheBuilderVisitor visitor = new PackageCacheBuilderVisitor();
+				try {
+					for (java.nio.file.Path path : roots) {
+						Files.walkFileTree(path, visitor);
+		 			}
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+				List<String> ls = new ArrayList<>();
+				ls.addAll(packageCache.keySet());
+				Collections.sort(ls);
+				moduleArchiveInfo = new ArchiveInfo(ls, false);
+			}
+			return moduleArchiveInfo;
+		}
+
+		/**
+		 * Walk the specified archive and collect up the package names of any .class files encountered. If
+		 * the archive contains nested jars packaged in a BOOT style way (under a BOOT-INF/lib folder) then
+		 * walk those too and include relevant packages.
+		 *
+		 * @param file archive file to discover packages from
+		 * @return an ArchiveInfo encapsulating package info from the archive
+		 */
+		private ArchiveInfo buildArchiveInfo(File file) {
+			if (file.toString().endsWith("jrt-fs.jar")) {
+				// Special treatment for >=JDK9 - treat this as intention to use modules
+				return buildPackageMap();
+			}
+			List<String> packageNames = new ArrayList<>();
+			boolean isBootJar = false;
+			try (ZipFile openArchive = new ZipFile(file)) {
+				Enumeration<? extends ZipEntry> entries = openArchive.entries();
+				while (entries.hasMoreElements()) {
+					ZipEntry entry = entries.nextElement();
+					String name = entry.getName();
+					if (name.endsWith(".class")) {
+						if (name.startsWith(BOOT_PACKAGING_PREFIX_FOR_CLASSES)) {
+							isBootJar = true;
+							int idx = name.lastIndexOf('/') + 1;
+							if (idx != 0 ) {
+								if (idx == BOOT_PACKAGING_PREFIX_FOR_CLASSES.length()) {
+									// default package
+									packageNames.add("/");
+								} else {
+									// Normalize to forward slashes
+									name = name.substring(BOOT_PACKAGING_PREFIX_FOR_CLASSES.length(), idx);
+									name = name.replace('\\', '/');
+									packageNames.add(name);
+								}
+							}
+						} else {
+							int idx = name.lastIndexOf('/') + 1;
+							if (idx != 0 ) {
+								// Normalize to forward slashes
+								name = name.replace('\\', '/');
+								name = name.substring(0, idx);
+								packageNames.add(name);
+							} else if (idx == 0) {
+								// default package entries in here
+								packageNames.add("/");
+							}
+						}
+					} else if (name.startsWith(BOOT_PACKAGING_PREFIX_FOR_LIBRARIES) && name.endsWith(".jar")) {
+						isBootJar = true;
+						try (ZipInputStream zis = new ZipInputStream(openArchive.getInputStream(entry))) {
+							Enumeration<? extends ZipEntry> nestedZipEnumerator = new ZipEnumerator(zis);
+							while (nestedZipEnumerator.hasMoreElements()) {
+								ZipEntry innerEntry = nestedZipEnumerator.nextElement();
+								String innerEntryName = innerEntry.getName();
+								if (innerEntryName.endsWith(".class")) {
+									int idx = innerEntryName.lastIndexOf('/') + 1;
+									if (idx != 0 ) {
+										// Normalize to forward slashes
+										innerEntryName = innerEntryName.replace('\\', '/');
+										innerEntryName = innerEntryName.substring(0, idx);
+										packageNames.add(innerEntryName);
+									} else if (idx == 0) {
+										// default package entries in here
+										packageNames.add("/");
+									}
+								}
+							}
+						}
+					}
+				}
+			} catch (IOException ioe) {
+				throw new IllegalStateException("Unexpected problem determining packages in "+file,ioe);
+			}
+			return new ArchiveInfo(packageNames, isBootJar);
+		}
+
+	}
+
+	static class Key {
+		private Location location;
+		private String classpath;
+		private String packageName;
+		private Set<Kind> kinds;
+		private boolean recurse;
+
+		public Key(Location location, String classpath, String packageName, Set<Kind> kinds, boolean recurse) {
+			this.location = location;
+			this.classpath = classpath;
+			this.packageName = packageName;
+			this.kinds = kinds;
+			this.recurse = recurse;
+		}
+
+		@Override
+		public int hashCode() {
+			return (((location.hashCode()*37)+classpath.hashCode()*37+(packageName==null?0:packageName.hashCode()))*37+kinds.hashCode())*37+(recurse?1:0);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!(obj instanceof Key)) {
+				return false;
+			}
+			Key that = (Key)obj;
+			return  location.equals(that.location) &&
+					classpath.equals(that.classpath) &&
+					kinds.equals(that.kinds) &&
+					(recurse==that.recurse) &&
+					(packageName==null?(that.packageName==null):this.packageName.equals(that.packageName));
+		}
+	}
+
+	private String getPlatformClassPath() {
+		if (platformClasspath == null) {
+			platformClasspath = System.getProperty("sun.boot.class.path");
+		}
+		if (platformClasspath == null) {
+			platformClasspath = "";
+		}
+		return platformClasspath;
+	}
+
+	@Override
+	public Iterable<JavaFileObject> list(Location location, String packageName,
+			Set<Kind> kinds, boolean recurse) throws IOException {
+		logger.debug("list({},{},{},{})", location, packageName, kinds, recurse);
+		String classpath = "";
+		Path moduleRootPath = null;
+		if (location instanceof JDKModuleLocation && (kinds == null || kinds.contains(Kind.CLASS))) {
+			// list(org.springframework.cloud.function.compiler.java.MemoryBasedJavaFileManager$JDKModuleLocation@550a1967,
+			//      java.lang,[SOURCE, CLASS, HTML, OTHER],false)
+			moduleRootPath = ((JDKModuleLocation)location).getModuleRootPath();
+			logger.info("For JDKModuleLocation "+location.toString()+" root path is "+moduleRootPath);
+		} else if (location == StandardLocation.PLATFORM_CLASS_PATH
+				&& (kinds == null || kinds.contains(Kind.CLASS))) {
+			classpath = getPlatformClassPath();
+//			if (classpath.length() == 0) {
+//			if (hasJrtFsPath()) {
+//				classpath = getJrtFsPath();
+//			}
+//		}
+			logger.debug("Creating iterable for boot class path: {}", classpath);
+		}
+		else if (location == StandardLocation.CLASS_PATH
+				&& (kinds == null || kinds.contains(Kind.CLASS))) {
+			String javaClassPath = getClassPath();
+			if (!resolvedAdditionalDependencies.isEmpty()) {
+				for (File resolvedAdditionalDependency : resolvedAdditionalDependencies
+						.values()) {
+					javaClassPath += File.pathSeparatorChar + resolvedAdditionalDependency
+							.toURI().toString().substring("file:".length());
+				}
+			}
+			classpath = javaClassPath;
+			logger.debug("Creating iterable for class path: {}", classpath);
+		}
+		Key k = new Key(location, classpath, packageName, kinds, recurse);
+		CloseableFilterableJavaFileObjectIterable resultIterable = iterables.get(k);
+		if (resultIterable == null) {
+			if (moduleRootPath != null) {
+				resultIterable = new IterableJrtModule(compilationInfoCache, moduleRootPath, packageName, recurse);
+			} else {
+				resultIterable = new IterableClasspath(compilationInfoCache, classpath, packageName, recurse);
+			}
+			iterables.put(k, resultIterable);
+		}
+		resultIterable.reset();
+		return resultIterable;
+	}
+
+	private String getClassPath() {
+		if (classpath == null) {
+			ClassLoader loader = InMemoryJavaFileObject.class.getClassLoader();
+			String cp = null;
+			if (loader instanceof URLClassLoader) {
+				URL[] urls = ((URLClassLoader) loader).getURLs();
+				if (urls.length > 1) { // heuristic that catches Maven surefire tests
+					if (!urls[0].toString().startsWith("jar:file:")) { // heuristic for Spring Boot fat jar
+						StringBuilder builder = new StringBuilder();
+						for (URL url : urls) {
+							if (builder.length() > 0) {
+								builder.append(File.pathSeparator);
+							}
+							String path = url.toString();
+							if (path.startsWith("file:")) {
+								path = path.substring("file:".length());
+							}
+							builder.append(path);
+						}
+						cp = builder.toString();
+					}
+				}
+			}
+			if (cp == null) {
+				cp = System.getProperty("java.class.path");
+			}
+			if (hasJrtFsPath()) {
+				cp = cp + File.pathSeparator + getJrtFsPath();
+			}
+			classpath = pathWithPlatformClassPathRemoved(cp);
+		}
+		return classpath;
+	}
+
+	// remove the platform classpath entries, they will be search separately (and earlier)
+	private String pathWithPlatformClassPathRemoved(String classpath) {
+		Set<String> pcps = toList(getPlatformClassPath());
+		Set<String> cps = toList(classpath);
+		cps.removeAll(pcps);
+		StringBuilder builder = new StringBuilder();
+		for (String cpe: cps) {
+			if (builder.length() > 0) {
+				builder.append(File.pathSeparator);
+			}
+			builder.append(cpe);
+		}
+		return builder.toString();
+	}
+
+	private Set<String> toList(String path) {
+		Set<String> result = new LinkedHashSet<>();
+		StringTokenizer tokenizer = new StringTokenizer(path,File.pathSeparator);
+		while (tokenizer.hasMoreTokens()) {
+			result.add(tokenizer.nextToken());
+		}
+		return result;
+	}
+
+	@Override
+	public boolean hasLocation(Location location) {
+		logger.debug("hasLocation({})", location);
+		return (location == StandardLocation.SOURCE_PATH
+				|| location == StandardLocation.CLASS_PATH
+				|| location == StandardLocation.PLATFORM_CLASS_PATH
+				|| (this.processorPath != null && location == StandardLocation.ANNOTATION_PROCESSOR_PATH));
+	}
+
+	@Override
+	public String inferBinaryName(Location location, JavaFileObject file) {
+		if (location == StandardLocation.SOURCE_PATH) {
+			return null;
+		}
+		// Kind of ignoring location here... assuming we want basically the FQ type name
+		// Example value from getName(): javax/validation/bootstrap/GenericBootstrap.class
+		String classname = file.getName().replace('/', '.').replace('\\', '.');
+		return classname.substring(0, classname.lastIndexOf(".class"));
+	}
+
+	@Override
+	public boolean isSameFile(FileObject a, FileObject b) {
+		logger.debug("isSameFile({},{})", a, b);
+		return a.equals(b);
+	}
+
+	@Override
+	public boolean handleOption(String current, Iterator<String> remaining) {
+		logger.debug("handleOption({},{})", current, remaining);
+		if (current.equals("-processorpath")) {
+			processorPath = remaining.next();
+			return true;
+		}
+		return false; // This file manager does not manage any options
+	}
+
+	@Override
+	public JavaFileObject getJavaFileForInput(Location location, String className,
+			Kind kind) throws IOException {
+		logger.info("getJavaFileForInput({},{},{})", location, className, kind);
+		// getJavaFileForInput(SOURCE_PATH,module-info,SOURCE)
+		if (className.equals("module-info")) {
+			return null;
+		}
+		throw new IllegalStateException("Not expected to be used in this context");
+	}
+
+	@Override
+	public JavaFileObject getJavaFileForOutput(Location location, String className,
+			Kind kind, FileObject sibling) throws IOException {
+		logger.debug("getJavaFileForOutput({},{},{},{})", location, className, kind,
+				sibling);
+		// Example parameters: CLASS_OUTPUT, Foo, CLASS,
+		// StringBasedJavaSourceFileObject[string:///a/b/c/Foo.java]
+		return InMemoryJavaFileObject.getJavaFileObject(this, location, className, kind, sibling);
+	}
+
+	@Override
+	public FileObject getFileForInput(Location location, String packageName,
+			String relativeName) throws IOException {
+		logger.debug("getFileForInput({},{},{})", location, packageName, relativeName);
+		throw new IllegalStateException("Not expected to be used in this context");
+	}
+
+	@Override
+	public FileObject getFileForOutput(Location location, String packageName,
+			String relativeName, FileObject sibling) throws IOException {
+		logger.debug("getFileForOutput({},{},{},{})", location, packageName, relativeName,
+				sibling);
+		// This can be called when the annotation config processor runs
+		// Example parameters: CLASS_OUTPUT, ,
+		// META-INF/spring-configuration-metadata.json, null
+		return InMemoryJavaFileObject.getFileObject(this, location, packageName, relativeName, sibling);
+	}
+
+	@Override
+	public void flush() throws IOException {
+	}
+
+	@Override
+	public void close() throws IOException {
+		Collection<CloseableFilterableJavaFileObjectIterable> toClose = iterables.values();
+		for (CloseableFilterableJavaFileObjectIterable icp: toClose) {
+			icp.close();
+		}
+	}
+	
+	public List<InMemoryJavaFileObject> getOutputFiles() {
+		return outputFiles;
+	}
+
+	public List<CompilationMessage> addAndResolveDependencies(String[] dependencies) {
+		List<CompilationMessage> resolutionMessages = new ArrayList<>();
+		for (String dependency : dependencies) {
+			if (dependency.startsWith("maven:")) {
+				// Resolving an explicit external archive
+				String coordinates = dependency.replaceFirst("maven:\\/*", "");
+				DependencyResolver engine = DependencyResolver.instance();
+				try {
+					File resolved = engine.resolve(
+							new Dependency(new DefaultArtifact(coordinates), "runtime"));
+					// Example:
+					// dependency =
+					// maven://org.springframework:spring-expression:4.3.9.RELEASE
+					// resolved.toURI() =
+					// file:/Users/aclement/.m2/repository/org/springframework/spring-expression/4.3.9.RELEASE/spring-expression-4.3.9.RELEASE.jar
+					resolvedAdditionalDependencies.put(dependency, resolved);
+				}
+				catch (RuntimeException re) {
+					CompilationMessage compilationMessage = new CompilationMessage(
+							CompilationMessage.Kind.ERROR, re.getMessage(), null, 0, 0);
+					resolutionMessages.add(compilationMessage);
+				}
+			} else if (dependency.startsWith("file:")) {
+				resolvedAdditionalDependencies.put(dependency, new File(URI.create(dependency)));
+			}
+			else {
+				resolutionMessages.add(new CompilationMessage(
+						CompilationMessage.Kind.ERROR,
+						"Unrecognized dependency: " + dependency
+								+ " (expected something of the form: maven://groupId:artifactId:version)",
+						null, 0, 0));
+			}
+		}
+		return resolutionMessages;
+	}
+
+	public void addResolvedDependencies(List<File> dependencies) {
+		for (File dependency : dependencies) {
+			resolvedAdditionalDependencies.put(dependency.toString(), dependency);
+		}
+	}
+
+	public Map<String, File> getResolvedAdditionalDependencies() {
+		return resolvedAdditionalDependencies;
+	}
+
+	private static URI JRT_URI = URI.create("jrt:/");
+	
+	private static FileSystem fs;
+	
+	static class JDKModuleLocation implements Location {
+		private String moduleName;
+		private Path moduleRootPath;
+		
+		public JDKModuleLocation(String moduleName, Path moduleRootPath) {
+			this.moduleName = moduleName;
+			this.moduleRootPath = moduleRootPath;
+		}
+
+		@Override
+		public String getName() {
+			return "MODULE";
+		}
+
+		@Override
+		public boolean isOutputLocation() {
+			return false;
+		}
+
+		public String getModuleName() {
+			return moduleName;
+		}
+		
+		public Path getModuleRootPath() {
+			return moduleRootPath;
+		}
+		
+		public String toString() {
+			return "JDKModuleLocation(" + moduleName + ")";
+		}
+
+		public int hashCode() {
+			return moduleName.hashCode();
+		}
+		
+		public boolean equals(Object other) {
+			if (!(other instanceof JDKModuleLocation)) {
+				return false;
+			}
+			return this.hashCode() == ((JDKModuleLocation)other).hashCode();
+		}
+		
+	}
+	
+	public String inferModuleName(Location location) throws IOException {
+		if (location instanceof JDKModuleLocation) {
+			JDKModuleLocation m = (JDKModuleLocation)location;
+			return m.getModuleName();
+		}
+		throw new IllegalStateException("Asked to inferModuleName from a "+location.getClass().getName());
+	}
+	
+	static class ModuleIdentifierVisitor extends SimpleFileVisitor<Path> {
+		
+		private Map<String, Path> modules = new HashMap<>();
+		
+		@Override
+		public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+			if (file.getNameCount() > 2 && file.toString().endsWith(".class")) {
+				// /modules/jdk.rmic/sun/tools/tree/CaseStatement.class
+				String moduleName = file.getName(1).toString(); // jdk.rmic
+				Path moduleRootPath = file.subpath(0, 2); // /modules/jdk.rmic
+				if (!modules.containsKey(moduleName)) {
+					modules.put(moduleName, moduleRootPath);
+				}
+			}
+			return FileVisitResult.CONTINUE;
+		}
+
+		public Set<Location> getModuleLocations() {
+			if (modules.size()==0) {
+				return Collections.emptySet();
+			} else {
+				Set<Location> locations = new HashSet<>();
+				for (Map.Entry<String,Path> moduleEntry: modules.entrySet()) {
+					locations.add(new JDKModuleLocation(moduleEntry.getKey(),moduleEntry.getValue()));
+				}
+				return locations;
+			}
+		}
+	}
+
+	private String jrtFsFilePath = null;
+	
+	private boolean checkedForJrtFsPath = false;
+
+	private boolean hasJrtFsPath() {
+		return getJrtFsPath() != null;
+	}
+	
+	private String getJrtFsPath() {
+		if (!checkedForJrtFsPath) {
+			String javaHome = System.getProperty("java.home");
+			String jrtFsFilePath = javaHome + File.separator + "lib" + File.separator + "jrt-fs.jar";
+			File jrtFsFile = new File(jrtFsFilePath);
+			if (jrtFsFile.exists()) {
+				this.jrtFsFilePath = jrtFsFilePath;
+			}
+			checkedForJrtFsPath = true;
+		}
+		return jrtFsFilePath;
+	}
+	
+	public Iterable<Set<Location>> listLocationsForModules(Location location) throws IOException {
+		if (getJrtFsPath()!=null && location == StandardLocation.valueOf("SYSTEM_MODULES")) {
+			Set<Set<Location>> ss = new HashSet<>();
+			HashSet<Location> moduleLocations = new HashSet<>();
+			ModuleIdentifierVisitor visitor = new ModuleIdentifierVisitor();
+			Iterable<Path> roots = getJrtFs().getRootDirectories();
+			try {
+				for (Path path: roots) {
+					Files.walkFileTree(path, visitor);
+				}
+				moduleLocations.addAll(visitor.getModuleLocations());
+			} catch (IOException ioe) {
+				throw new RuntimeException(ioe);
+			}
+			ss.add(moduleLocations);
+			return ss;
+		} else {
+			return Collections.emptySet();
+		}
+	}
+
+	private static FileSystem getJrtFs() {
+		if (fs == null) {
+			 fs = FileSystems.getFileSystem(JRT_URI);
+		}
+		return fs;
+	}
+
+	public void recordWrite(InMemoryJavaFileObject jfo) {
+		outputFiles.add(jfo);
+	}
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/NestedZipEntryJavaFileObject.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/NestedZipEntryJavaFileObject.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
+import javax.tools.JavaFileObject;
+
+/**
+ * Represents an element inside in zip which is itself inside a zip. These objects are
+ * not initially created with the content of the file they represent,
+ * only enough information to find that content because many will
+ * typically be created but only few will be opened.
+ * 
+ * @author Andy Clement
+ */
+public class NestedZipEntryJavaFileObject implements JavaFileObject {
+
+	private File outerFile;
+	private ZipFile outerZipFile;
+	private ZipEntry innerZipFile;
+	private ZipEntry innerZipFileEntry;
+
+	private URI uri;
+
+	public NestedZipEntryJavaFileObject(File outerFile, ZipFile outerZipFile, ZipEntry innerZipFile, ZipEntry innerZipFileEntry) {
+		this.outerFile = outerFile;
+		this.outerZipFile = outerZipFile;
+		this.innerZipFile = innerZipFile;
+		this.innerZipFileEntry = innerZipFileEntry;
+	}
+
+	@Override
+	public String getName() {
+		return innerZipFileEntry.getName(); // Example: a/b/C.class
+	}
+
+	@Override
+	public URI toUri() {
+		if (uri == null) {
+			String uriString = null;
+			try {
+				uriString = "zip:"+outerFile.getAbsolutePath()+"!"+innerZipFile.getName()+"!"+innerZipFileEntry.getName();
+				uri = new URI(uriString);
+			} catch (URISyntaxException e) {
+				throw new IllegalStateException("Unexpected URISyntaxException for string '"+uriString+"'",e);
+			}
+		}
+		return uri;
+	}
+	
+	@Override
+	public InputStream openInputStream() throws IOException {
+		// Find the inner zip file inside the outer zip file, then
+		// find the relevant entry, then return the stream.
+		InputStream innerZipFileInputStream = this.outerZipFile.getInputStream(innerZipFile);
+		ZipInputStream innerZipInputStream = new ZipInputStream(innerZipFileInputStream);
+		ZipEntry nextEntry = innerZipInputStream.getNextEntry();
+		while (nextEntry != null) {
+			if (nextEntry.getName().equals(innerZipFileEntry.getName())) {
+				return innerZipInputStream;
+			}
+			nextEntry = innerZipInputStream.getNextEntry();
+		}
+		throw new IllegalStateException("Unable to locate nested zip entry "+innerZipFileEntry.getName()+" in zip "+innerZipFile.getName()+" inside zip "+outerZipFile.getName());
+	}
+
+	@Override
+	public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
+		// It is bytecode
+		throw new UnsupportedOperationException("getCharContent() not supported on class file: " + getName());
+	}
+
+	@Override
+	public long getLastModified() {
+		return innerZipFileEntry.getTime();
+	}
+
+	@Override
+	public Kind getKind() {
+		// The filtering before this object was created ensure it is only used for classes
+		return Kind.CLASS;
+	}
+
+	@Override
+	public boolean delete() {
+		return false; // Cannot delete entries inside nested zips
+	}
+	
+	@Override
+	public OutputStream openOutputStream() throws IOException {
+		throw new IllegalStateException("cannot write to nested zip entry: "+toUri());
+	}
+	
+	@Override
+	public Writer openWriter() throws IOException {
+		throw new IllegalStateException("cannot write to nested zip entry: "+toUri());
+	}
+
+	@Override
+	public boolean isNameCompatible(String simpleName, Kind kind) {
+		if (kind != Kind.CLASS) {
+			return false;
+		}
+		String name = getName();
+		int lastSlash = name.lastIndexOf('/');
+		return name.substring(lastSlash+1).equals(simpleName+".class");
+	}
+
+	@Override
+	public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+		// It is bytecode
+		throw new UnsupportedOperationException("getCharContent() not supported on class file: " + getName());
+	}
+
+	@Override
+	public NestingKind getNestingKind() {
+		return null; // nesting level not known
+	}
+
+	@Override
+	public Modifier getAccessLevel() {
+		return null; // access level not known
+	}
+	
+	@Override
+	public int hashCode() {
+		int hc = outerFile.getName().hashCode();
+		hc = hc * 37 + innerZipFile.getName().hashCode();
+		hc = hc * 37 + innerZipFileEntry.getName().hashCode();
+		return hc;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof NestedZipEntryJavaFileObject)) {
+			return false;
+		}
+		NestedZipEntryJavaFileObject that = (NestedZipEntryJavaFileObject)obj;
+		return  (outerFile.getName().equals(that.outerFile.getName())) &&
+				(innerZipFile.getName().equals(that.innerZipFile.getName())) &&
+				(innerZipFileEntry.getName().equals(that.innerZipFileEntry.getName()));
+	}
+	
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/RuntimeJavaCompiler.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/RuntimeJavaCompiler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.tools.Diagnostic;
+import javax.tools.Diagnostic.Kind;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileObject;
+import javax.tools.ToolProvider;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Compile Java source at runtime and load it.
+ *
+ * @author Andy Clement
+ */
+public class RuntimeJavaCompiler {
+
+	private static Logger logger = LoggerFactory.getLogger(RuntimeJavaCompiler.class);
+
+	private JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+
+	public CompilationResult compile(InputFileDescriptor[] sources, InputFileDescriptor[] resources, CompilationOptions compilationOptions, List<File> dependencies) {
+		logger.debug("Compiling {} source{}",sources.length, sources.length==1?"":"s");
+		DiagnosticCollector<JavaFileObject> diagnosticCollector = new DiagnosticCollector<JavaFileObject>();
+		MemoryBasedJavaFileManager fileManager = new MemoryBasedJavaFileManager();
+		fileManager.addResolvedDependencies(dependencies);
+		List<JavaFileObject> compilationUnits = new ArrayList<>();
+		for (InputFileDescriptor source: sources) {
+			compilationUnits.add(InMemoryJavaFileObject.getSourceJavaFileObject(source.getClassName(), source.getContent()));
+		}
+		List<String> options = new ArrayList<>();
+		options.add("-processorpath");
+		options.add(new File("../processor/target/classes/").toString());
+		options.add("-source");
+		options.add("1.8");
+		options.add("-processor");
+		options.add("processor.SlimConfigurationProcessor");
+		CompilationTask task = compiler.getTask(null, fileManager , diagnosticCollector, options,  null, compilationUnits);
+		boolean success = task.call();
+		CompilationResult compilationResult = new CompilationResult(success);
+		compilationResult.setDependencies(new ArrayList<>(fileManager.getResolvedAdditionalDependencies().values()));
+		compilationResult.setInputResources(resources);
+		// If successful there may be no errors but there might be info/warnings
+		for (Diagnostic<? extends JavaFileObject> diagnostic : diagnosticCollector.getDiagnostics()) {
+			CompilationMessage.Kind kind = (diagnostic.getKind()==Kind.ERROR?CompilationMessage.Kind.ERROR:CompilationMessage.Kind.OTHER);
+			String sourceCode =null;
+			try {
+				sourceCode = (String)diagnostic.getSource().getCharContent(true);
+			}
+			catch (IOException ioe) {
+				// Unexpected, but leave sourceCode null to indicate it was not retrievable
+			}
+			catch (NullPointerException npe) {
+				// TODO: should we skip warning diagnostics in the loop altogether?
+			}
+			int startPosition = (int)diagnostic.getPosition();
+			if (startPosition == Diagnostic.NOPOS) {
+				startPosition = (int)diagnostic.getStartPosition();
+			}
+			CompilationMessage compilationMessage = new CompilationMessage(kind,diagnostic.getMessage(null),sourceCode,startPosition,(int)diagnostic.getEndPosition());
+			compilationResult.recordCompilationMessage(compilationMessage);
+		}
+		compilationResult.setGeneratedFiles(fileManager.getOutputFiles());
+		return compilationResult;
+	}
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/SimpleClassLoader.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/SimpleClassLoader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.List;
+
+/**
+ * Very simple classloader that can be used to load the compiled types.
+ * 
+ * @author Andy Clement
+ */
+public class SimpleClassLoader extends URLClassLoader {
+
+	private static final URL[] NO_URLS = new URL[0];
+
+	public SimpleClassLoader(ClassLoader classLoader) {
+		super(NO_URLS, classLoader);
+	}
+
+	public SimpleClassLoader(List<File> resolvedAdditionalDependencies, ClassLoader classLoader) {
+		super(toUrls(resolvedAdditionalDependencies), classLoader);
+	}
+
+	private static URL[] toUrls(List<File> resolvedAdditionalDependencies) {
+		URL[] urls = new URL[resolvedAdditionalDependencies.size()];
+		for (int i=0,max=resolvedAdditionalDependencies.size();i<max;i++) {
+			try {
+				urls[i] = resolvedAdditionalDependencies.get(i).toURI().toURL();
+			} catch (Exception e) {
+				throw new IllegalStateException(e);
+			}
+		}
+		return urls;
+	}
+
+	public Class<?> defineClass(String name, byte[] bytes) {
+		return super.defineClass(name, bytes, 0, bytes.length);
+	}
+}

--- a/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/ZipEntryJavaFileObject.java
+++ b/modules/processor-tests/src/test/java/org/springframework/cloud/function/compiler/java/ZipEntryJavaFileObject.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2016 the original author or authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.function.compiler.java;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.NestingKind;
+import javax.tools.JavaFileObject;
+
+public class ZipEntryJavaFileObject implements JavaFileObject {
+
+	private File containingFile;
+	private ZipFile zf;
+	private ZipEntry ze;
+
+	private URI uri;
+
+	public ZipEntryJavaFileObject(File containingFile, ZipFile zipFile, ZipEntry entry) {
+		this.containingFile = containingFile;
+		this.zf = zipFile;
+		this.ze = entry;
+	}
+
+	@Override
+	public URI toUri() {
+		if (uri == null) {
+			String uriString = null;
+			try {
+				uriString = "zip:" + containingFile.getAbsolutePath() + "!" + ze.getName();
+				uri = new URI(uriString);
+			} catch (URISyntaxException e) {
+				throw new IllegalStateException("Unexpected URISyntaxException for string '" + uriString + "'", e);
+			}
+		}
+		return uri;
+	}
+
+	@Override
+	public String getName() {
+		return ze.getName(); // a/b/C.class
+	}
+
+	@Override
+	public InputStream openInputStream() throws IOException {
+		return zf.getInputStream(ze);
+	}
+
+	@Override
+	public OutputStream openOutputStream() throws IOException {
+		throw new IllegalStateException("only expected to be used for input");
+	}
+
+	@Override
+	public Reader openReader(boolean ignoreEncodingErrors) throws IOException {
+		// It is bytecode
+		throw new UnsupportedOperationException("openReader() not supported on class file: " + getName()); 
+	}
+
+	@Override
+	public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+		// It is bytecode
+		throw new UnsupportedOperationException("getCharContent() not supported on class file: " + getName());
+	}
+
+	@Override
+	public Writer openWriter() throws IOException {
+		throw new IllegalStateException("only expected to be used for input");
+	}
+
+	@Override
+	public long getLastModified() {
+		return ze.getTime();
+	}
+
+	@Override
+	public boolean delete() {
+		return false; // Cannot delete entries inside zips
+	}
+
+	@Override
+	public Kind getKind() {
+		return Kind.CLASS;
+	}
+
+	@Override
+	public boolean isNameCompatible(String simpleName, Kind kind) {
+		if (kind != Kind.CLASS) {
+			return false;
+		}
+		String name = getName();
+		int lastSlash = name.lastIndexOf('/');
+		return name.substring(lastSlash + 1).equals(simpleName + ".class");
+	}
+
+	@Override
+	public NestingKind getNestingKind() {
+		return null;
+	}
+
+	@Override
+	public Modifier getAccessLevel() {
+		return null;
+	}
+
+	@Override
+	public int hashCode() {
+		int hc = containingFile.getName().hashCode();
+		hc = hc * 37 + ze.getName().hashCode();
+		return hc;
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof ZipEntryJavaFileObject)) {
+			return false;
+		}
+		ZipEntryJavaFileObject that = (ZipEntryJavaFileObject)obj;
+		return  (containingFile.getName().equals(that.containingFile.getName())) &&
+				(ze.getName().equals(that.ze.getName()));
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/slim/processor/infra/CompilerRunner.java
+++ b/modules/processor-tests/src/test/java/org/springframework/slim/processor/infra/CompilerRunner.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.slim.processor.infra;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.cloud.function.compiler.java.CompilationMessage;
+import org.springframework.cloud.function.compiler.java.CompilationOptions;
+import org.springframework.cloud.function.compiler.java.CompilationResult;
+import org.springframework.cloud.function.compiler.java.InputFileDescriptor;
+import org.springframework.cloud.function.compiler.java.InMemoryJavaFileObject;
+import org.springframework.cloud.function.compiler.java.RuntimeJavaCompiler;
+
+/**
+ * @author Andy Clement
+ */
+public class CompilerRunner {
+
+	public static CompilationResult run(InputFileDescriptor fd) {
+		List<InputFileDescriptor> sources = new ArrayList<>();
+		sources.add(fd);
+		return run(sources,Collections.emptyList(), Collections.emptyList());
+	}
+
+	public static CompilationResult run(InputFileDescriptor fd, List<File> dependencies) {
+		List<InputFileDescriptor> sources = new ArrayList<>();
+		sources.add(fd);
+		return run(sources,Collections.emptyList(), dependencies);
+	}
+
+	public static CompilationResult run(Collection<InputFileDescriptor> sources, Collection<InputFileDescriptor> resources, List<File> dependencies) {
+		RuntimeJavaCompiler compiler = new RuntimeJavaCompiler();
+		CompilationOptions options = new CompilationOptions();
+		boolean hasErrors = false;
+		System.out.println("Starting compiler...");
+		CompilationResult result = compiler.compile(sources.toArray(new InputFileDescriptor[0]),resources.toArray(new InputFileDescriptor[0]), options, dependencies);
+		List<CompilationMessage> compilationMessages = result.getCompilationMessages();
+		for (CompilationMessage compilationMessage : compilationMessages) {
+			if (compilationMessage.getKind().toString().equals("ERROR")) {
+				hasErrors = true;
+			}
+		}
+		if (hasErrors) {
+			throw new IllegalStateException("Compilation failed, see errors");
+		} else {
+			System.out.println("Compilation completed OK");
+		}
+		// printCompilationSummary(result);
+		return result;
+	}
+
+	@SuppressWarnings("unused")
+	private static void printCompilationSummary(CompilationResult cr) {
+		List<InMemoryJavaFileObject> compiledClasses = cr.getGeneratedFiles();
+		if (compiledClasses == null) {
+			System.out.println("NO CLASSES COMPILED");
+			return;
+		}
+		System.out.println("Output files:");
+		for (InMemoryJavaFileObject compiledClassDefinition : compiledClasses) {
+			byte[] bytes = compiledClassDefinition.getBytes();
+			System.out.println(compiledClassDefinition.getName() + " size:" + (bytes == null ? "NULL" : bytes.length));
+		}
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/slim/processor/infra/Utils.java
+++ b/modules/processor-tests/src/test/java/org/springframework/slim/processor/infra/Utils.java
@@ -1,0 +1,378 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.slim.processor.infra;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.function.compiler.java.CompilationResult;
+import org.springframework.cloud.function.compiler.java.DependencyResolver;
+import org.springframework.cloud.function.compiler.java.InMemoryJavaFileObject;
+import org.springframework.cloud.function.compiler.java.InputFileDescriptor;
+import org.springframework.core.io.FileUrlResource;
+import org.springframework.util.ClassUtils;
+
+/**
+ * @author Andy Clement
+ */
+public class Utils {
+
+	public final static String PROJECT = "spring-init-experiment";
+	
+	private final static Logger logger = LoggerFactory.getLogger(Utils.class);
+	
+	public static Map<File, List<File>> resolvedDependenciesCache = new HashMap<>();
+
+	public static Set<String> findImports(InputFileDescriptor sourceFile) {
+		Pattern pkg = Pattern.compile("^package.* ([.a-zA-Z]*).*;.*$");
+		Pattern p = Pattern.compile("^import.* ([.a-zA-Z]*)\\.[a-zA-Z\\*]*;.*$");
+		return Arrays.stream(sourceFile.getContent().split("\\n")).flatMap(l -> {
+			Matcher mat = pkg.matcher(l);
+			Set<String> s = new HashSet<>();
+			while (mat.find()) {
+				s.add(mat.group(1));
+			}
+			mat = p.matcher(l);
+			while (mat.find()) {
+				s.add(mat.group(1));
+			}
+			return s.stream();
+		}).collect(Collectors.toSet());
+	}
+
+	public static File resolveJunitConsoleLauncher() {
+		DependencyResolver engine = DependencyResolver.instance();
+		Artifact junitLauncherArtifact = new DefaultArtifact("org.junit.platform:junit-platform-console-standalone:1.3.1");
+		Dependency junitLauncherDependency = new Dependency(junitLauncherArtifact, "test");
+		File file = engine.resolve(junitLauncherDependency);
+		return file;
+	}
+	
+	/**
+	 * Use maven to resolve the dependencies of the specified folder (expected to
+	 * contain a pom), and then resolve them to either entries in the maven cache or
+	 * as target/classes folders in other modules in this project build.
+	 * 
+	 * @param projectRootFolder the project to be resolved (should contain the
+	 *                          pom.xml)
+	 * @return a list of jars/folders - folders used for local
+	 */
+	public static List<File> resolveProjectDependencies(File projectRootFolder) {
+		List<File> resolvedDependencies = resolvedDependenciesCache.get(projectRootFolder);
+		if (resolvedDependencies == null) {
+			long stime = System.currentTimeMillis();
+			DependencyResolver engine = DependencyResolver.instance();
+			try {
+				File f = new File(projectRootFolder, "pom.xml");
+				List<Dependency> dependencies = engine.dependencies(new FileUrlResource(f.toURI().toURL()));
+				resolvedDependencies = new ArrayList<>();
+				for (Dependency dependency : dependencies) {
+					File resolvedDependency = null;
+					// Example: spring-init-experiment:tests-lib:jar:1.0-SNAPSHOT
+					if (dependency.toString().startsWith(PROJECT+":")) {
+						// Resolve locally
+						StringTokenizer st = new StringTokenizer(dependency.toString(), ":");
+						st.nextToken();
+						String submodule = st.nextToken();
+						resolvedDependency = new File(projectRootFolder, "../" + submodule + "/target/classes")
+								.getCanonicalFile();
+						if (!resolvedDependency.exists()) {
+							// try another place
+							resolvedDependency = new File(projectRootFolder, "../../modules/" + submodule + "/target/classes")
+									.getCanonicalFile();
+						}
+						if (!resolvedDependency.exists()) {
+							System.out.println("Bad miss? " + resolvedDependency.getAbsolutePath().toString());
+							resolvedDependency = null;
+						}
+					} else {
+						resolvedDependency = engine.resolve(dependency);
+					}
+					resolvedDependencies.add(resolvedDependency);
+				}
+				logger.debug("Resolved #{} dependencies in {}ms", resolvedDependencies.size(), (System.currentTimeMillis()-stime));
+				resolvedDependenciesCache.put(projectRootFolder, Collections.unmodifiableList(resolvedDependencies));
+			} catch (Throwable e) {
+				throw new IllegalStateException("Unexpected problem resolving dependencies", e);
+			}
+		}
+		return resolvedDependencies;
+	}
+
+	static class CompilationResultClassLoader extends URLClassLoader {
+
+		private CompilationResult cr;
+		File f;
+
+		public CompilationResultClassLoader(List<File> dependencies, CompilationResult cr, ClassLoader parent) {
+			super(toUrls(dependencies), parent);
+			f = dependencies.get(0);
+			this.cr = cr;
+		}
+
+		protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+			synchronized (getClassLoadingLock(name)) {
+				// First, check if the class has already been loaded
+
+				Class<?> c = findLoadedClass(name);
+				if (c != null) {
+					if (resolve) {
+						resolveClass(c);
+					}
+					return c;
+				}
+				// Child first...
+				try {
+					Class<?> findClass = findClass(name);
+					if (findClass != null) {
+						if (resolve) {
+							resolveClass(findClass);
+						}
+						return findClass;
+					}
+				} catch (ClassNotFoundException ncfe) {
+//	        		ncfe.printStackTrace();
+				}
+//	            Class<?> c = findLoadedClass(name);
+//	            if (c == null) {
+//	            	if (cr != null) {
+//	    				for (CompiledClassDefinition ccd: cr.getCcds()) {
+//	    					if (ccd.getClassName().equals(name)) {
+//	    						byte[] bs = ccd.getBytes();
+//	    						try {
+//	    							System.out.println("Defining class "+name);
+//	    							c = defineClass(name, bs, 0, bs.length);
+//	    				            if (resolve) {
+//	    				                resolveClass(c);
+//	    				            }
+//	    							return c;
+//	    						} catch (ClassFormatError cfe) {
+//	    							cfe.printStackTrace();
+//	    							break;
+//	    						}
+//	    					}
+//	    				}
+//	    			}
+
+				return super.loadClass(name, resolve);
+
+//	                long t0 = System.nanoTime();
+//	                try {
+//	                    if (parent != null) {
+//	                        c = parent.loadClass(name, false);
+//	                    } else {
+//	                        c = findBootstrapClassOrNull(name);
+//	                    }
+//	                } catch (ClassNotFoundException e) {
+//	                    // ClassNotFoundException thrown if class not found
+//	                    // from the non-null parent class loader
+//	                }
+//
+//	                if (c == null) {
+//	                    // If still not found, then invoke findClass in order
+//	                    // to find the class.
+//	                    long t1 = System.nanoTime();
+//	                    c = findClass(name);
+//
+//	                    // this is the defining class loader; record the stats
+//	                    sun.misc.PerfCounter.getParentDelegationTime().addTime(t1 - t0);
+//	                    sun.misc.PerfCounter.getFindClassTime().addElapsedTimeFrom(t1);
+//	                    sun.misc.PerfCounter.getFindClasses().increment();
+//	                }
+//	            }
+//	            if (resolve) {
+//	                resolveClass(c);
+//	            }
+//	            return c;
+			}
+		}
+
+		// name = java.lang.String
+		protected java.lang.Class<?> findClass(String name) throws ClassNotFoundException {
+//			System.out.println("Looking for " + name);
+			if (cr != null) {
+				for (InMemoryJavaFileObject ccd : cr.getGeneratedFiles()) {
+					if (ccd.getName().equals(name)) {
+						byte[] bs = ccd.getBytes();
+						try {
+							System.out.println("Defining class " + name);
+							Class<?> c = defineClass(name, bs, 0, bs.length);
+							return c;
+						} catch (ClassFormatError cfe) {
+							cfe.printStackTrace();
+							break;
+						}
+					}
+				}
+			}
+			return super.findClass(name);
+		};
+
+		@Override
+		public Enumeration<URL> findResources(String name) throws IOException {
+//			System.out.println("Asked to find resources: " + name);
+			Enumeration<URL> findResources = super.findResources(name);
+//			 System.out.println("Found any?"+findResources.hasMoreElements());
+//			 new URL()
+			List<URL> ls = new ArrayList<>();
+			if (!findResources.hasMoreElements() && cr != null) {
+				for (InMemoryJavaFileObject ccd : cr.getGeneratedFiles()) {
+					if (ccd.getName().equals(name)) {
+//							byte[] bs = ccd.getBytes();
+						URL url = new URL("jar:file:/" + f.toString() + "!/" + ccd.getName());
+						System.out.println(url);
+//							try {
+//								System.out.println("Defining class "+name);
+//								Class<?> c = defineClass(name, bs, 0, bs.length);
+//								return c;
+//							} catch (ClassFormatError cfe) {
+//								cfe.printStackTrace();
+//								break;
+//							}
+					}
+				}
+			}
+			return ls.size() == 0 ? findResources : Collections.enumeration(ls);
+//			 return findResources;
+		}
+
+		public URL findResource(String name) {
+//			System.out.println("Asked to find resource " + name);
+//			for (CompiledClassDefinition ccd: cr.getCcds()) {
+////				if (ccd.getClassName().equals(name)) {
+//					System.out.println(" - checking "+ccd.getClassName());
+////				}
+//			}
+//			if (true) throw new IllegalStateException("!!"+name);
+			return super.findResource(name);
+		};
+
+		private static URL[] toUrls(List<File> dependencies) {
+			return dependencies.stream().map(f -> {
+				try {
+					return f.toURI().toURL();
+				} catch (MalformedURLException e) {
+					e.printStackTrace();
+					return null;
+				}
+			}).collect(Collectors.toList()).toArray(new URL[0]);
+		}
+
+	}
+
+	public static ClassLoader getCompilationResultClassLoader(List<File> dependencies, CompilationResult result, ClassLoader parent) {
+		return new CompilationResultClassLoader(dependencies, result,parent);
+	}
+
+	public static Map<File, List<InputFileDescriptor>> filesCache = new HashMap<>();
+
+	public static List<InputFileDescriptor> getFiles(File rootFolder) {
+		List<InputFileDescriptor> sourcesInFolder = filesCache.get(rootFolder);
+		if (sourcesInFolder == null) {
+			final List<InputFileDescriptor> collectedFiles = new ArrayList<>();
+			try {
+				Files.walkFileTree(rootFolder.toPath(), new SimpleFileVisitor<Path>() {
+					@Override
+					public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+						File relativeFile = rootFolder.toPath().relativize(file).toFile();
+						collectedFiles.add(new InputFileDescriptor(file.toFile(), relativeFile.toString(),
+								guessClassName(rootFolder.toPath().relativize(file).toFile())));
+						return super.visitFile(file, attrs);
+					}
+
+					private String guessClassName(File file) {
+						String s = file.toString();
+						if (s.endsWith(".java")) {
+							return s.substring(0, s.length() - 5).replace("/", ".");
+						} else {
+							return null;
+						}
+					}
+				});
+			} catch (NoSuchFileException nsfe) {
+			} catch (IOException e) {
+				throw new IllegalStateException("Problems walking folder: " + rootFolder, e);
+			}
+			sourcesInFolder = Collections.unmodifiableList(collectedFiles);
+			filesCache.put(rootFolder, sourcesInFolder);
+		}
+		return sourcesInFolder;
+	}
+
+	public static void executeTests(CompilationResult result,
+				List<File> dependencies, InputFileDescriptor... testFiles) {
+			try {
+				List<File> fullDependencies = new ArrayList<>(dependencies);
+				fullDependencies.add(resolveJunitConsoleLauncher());
+				ClassLoader cl = getCompilationResultClassLoader(fullDependencies, result, Thread.currentThread().getContextClassLoader().getParent());
+				Thread.currentThread().setContextClassLoader(cl);
+
+				Class<?> junitLauncher = ClassUtils.forName("org.junit.platform.console.ConsoleLauncher", cl);
+				// Call execute rather than main to avoid process exit
+				Method declaredMethod = junitLauncher.getDeclaredMethod("execute", PrintStream.class, PrintStream.class,
+						String[].class);
+				// Type of o is ConsoleLauncherExecutionResult
+				List<String> options = new ArrayList<>();
+				for (InputFileDescriptor testFile: testFiles) {
+					options.add("-c");
+					options.add(testFile.getClassName());
+				}
+				options.add("--details");
+				options.add("tree");
+				System.out.println(options);
+				Object o = declaredMethod.invoke(null, System.out, System.err, (Object)options.toArray(new String[] {}));
+	//					(Object) new String[] { "-c", testSourceFile.getClassName(), "--details", "none" });
+				Method getExitCode = ClassUtils.forName("org.junit.platform.console.ConsoleLauncherExecutionResult", cl).getDeclaredMethod("getExitCode");
+				Integer i = (Integer)getExitCode.invoke(o);
+				if (i != 0) {
+					throw new IllegalStateException("Test failed");
+				}
+			} catch (Exception e) {
+				e.printStackTrace();
+				throw new IllegalStateException("Failed", e);
+			}
+		}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/slim/processor/tests/ModuleTests.java
+++ b/modules/processor-tests/src/test/java/org/springframework/slim/processor/tests/ModuleTests.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.slim.processor.tests;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.cloud.function.compiler.java.CompilationResult;
+import org.springframework.cloud.function.compiler.java.InputFileDescriptor;
+import org.springframework.slim.processor.infra.CompilerRunner;
+import org.springframework.slim.processor.infra.Utils;
+
+/**
+ * Find the *Tests.java in the module/tests/src/test/java folder, pull together the related
+ * sources and compile and run the test.
+ * 
+ * @author Andy Clement
+ */
+public class ModuleTests {
+
+	private static File moduleTestsFolder = new File("../tests");
+
+	@TestFactory
+	public Stream<DynamicTest> moduleTests() {
+		if (!System.getProperty("generatedTests","false").equalsIgnoreCase("true")) {
+			return Stream.empty();
+		}
+		return findExistingTests().stream()
+				.map(f -> DynamicTest.dynamicTest(f.getClassName(), () -> runTest(f)));
+	}
+
+	/**
+	 * @return files matching: module/tests/src/test/java/*Tests.java
+	 */
+	List<InputFileDescriptor> findExistingTests() {
+		return Utils.getFiles(new File(moduleTestsFolder,"src/test/java")).stream()
+				.filter(f -> f.getClassName().endsWith("Tests"))
+				.collect(Collectors.toList());
+	}
+
+	private static void runTest(InputFileDescriptor testSourceFile) {
+		Set<InputFileDescriptor> inputForCompiler = new HashSet<>();
+		inferOtherSources(testSourceFile, inputForCompiler);
+		Set<InputFileDescriptor> resources = new HashSet<>();
+		resources.addAll(Utils.getFiles(new File(moduleTestsFolder, "src/main/resources")));
+		resources.addAll(Utils.getFiles(new File(moduleTestsFolder, "src/test/resources")));
+		List<File> dependencies = new ArrayList<>(resolveModuleTestsProjectDependencies());
+		System.out.println("For test " + testSourceFile.getClassName());
+		System.out.println(" - compiling #" + inputForCompiler.size() + " sources");
+		System.out.println(" - resources #" + resources.size() + " files");
+		System.out.println(" - dependencies #" + dependencies.size());
+		CompilationResult result = CompilerRunner.run(inputForCompiler, resources, dependencies);
+		dependencies.add(0, result.dumpToTemporaryJar());
+		Utils.executeTests(result, dependencies, testSourceFile);
+	}
+
+	private static List<File> resolveModuleTestsProjectDependencies() {
+		return Utils.resolveProjectDependencies(moduleTestsFolder);
+	}
+
+	private static void inferOtherSources(InputFileDescriptor testclass, Set<InputFileDescriptor> collector) {
+		Set<String> importedPackages = Utils.findImports(testclass);
+		String thisPkg = testclass.getPackageName();
+		collector.add(testclass);
+		// Find other Java sources in those packages that we should include
+		List<InputFileDescriptor> mainJavaSources = Utils.getFiles(new File(moduleTestsFolder,"src/main/java")).stream()
+				.filter(f -> importedPackages.contains(f.getPackageName())).collect(Collectors.toList());
+		for (InputFileDescriptor f : mainJavaSources) {
+			if (collector.add(f) && !f.getPackageName().equals(thisPkg)) {
+				inferOtherSources(f, collector);
+			}
+		}
+		List<InputFileDescriptor> testJavaSources = Utils.getFiles(new File(moduleTestsFolder,"src/test/java")).stream()
+				.filter(f -> importedPackages.contains(f.getPackageName())).collect(Collectors.toList());
+		for (InputFileDescriptor f : testJavaSources) {
+			if (collector.add(f) && !f.getPackageName().equals(thisPkg)) {
+				inferOtherSources(f, collector);
+			}
+		}
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/slim/processor/tests/SamplesTests.java
+++ b/modules/processor-tests/src/test/java/org/springframework/slim/processor/tests/SamplesTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.slim.processor.tests;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.cloud.function.compiler.java.CompilationResult;
+import org.springframework.cloud.function.compiler.java.InputFileDescriptor;
+import org.springframework.slim.processor.infra.CompilerRunner;
+import org.springframework.slim.processor.infra.Utils;
+
+/**
+ * Find the tests in the samples/XXX folder, pull together the related
+ * sources and compile and run the tests. The tests within a sample are run together under one
+ * generated test.
+ * 
+ * @author Andy Clement
+ */
+public class SamplesTests {
+
+	private static File samplesFolder = new File("../../samples");
+
+	@TestFactory
+	Stream<DynamicTest> samples() {
+		if (!System.getProperty("generatedTests","false").equalsIgnoreCase("true")) {
+			return Stream.empty();
+		}
+		return Arrays.asList(samplesFolder.listFiles()).stream()
+				.filter(f -> f.isDirectory() && new File(f,"pom.xml").exists()).
+				map(f -> DynamicTest.dynamicTest(f.getName(), () -> runTest(f)));
+	}
+	
+	private static void runTest(File sampleFolder) {
+		List<InputFileDescriptor> testFiles = Utils.getFiles(new File(sampleFolder,"src/test/java")).stream().filter(f -> f.getClassName().endsWith("Tests"))
+			.collect(Collectors.toList());
+		Set<InputFileDescriptor> inputForCompiler = new HashSet<>();
+		inputForCompiler.addAll(Utils.getFiles(new File(sampleFolder,"src/main/java")));
+		inputForCompiler.addAll(Utils.getFiles(new File(sampleFolder,"src/test/java")));
+		Set<InputFileDescriptor> resources = new HashSet<>();
+		resources.addAll(Utils.getFiles(new File(sampleFolder,"src/main/resources")));
+		resources.addAll(Utils.getFiles(new File(sampleFolder,"src/test/resources")));
+		long stime = System.currentTimeMillis();
+		List<File> junitDeps = 
+				Utils.resolveProjectDependencies(new File("."))
+					.stream().filter(d -> d.toString().contains("junit")).collect(Collectors.toList());
+		System.out.println("Timer: resolve deps: #"+(System.currentTimeMillis()-stime)+"ms");
+		stime = System.currentTimeMillis();
+		List<File> dependencies = new ArrayList<>(Utils.resolveProjectDependencies(sampleFolder));
+		System.out.println("Timer: resolve deps2: #"+(System.currentTimeMillis()-stime)+"ms");
+		dependencies.addAll(junitDeps);
+		System.out.println("For sample " + sampleFolder);
+		System.out.println(" - compiling #" + inputForCompiler.size() + " sources");
+		System.out.println(" - resources #" + resources.size() + " files");
+		System.out.println(" - dependencies #" + dependencies.size());
+		System.out.println(dependencies);
+		stime=System.currentTimeMillis();
+		CompilationResult result = CompilerRunner.run(inputForCompiler, resources, dependencies);
+		System.out.println("Timer: compiler run: #"+(System.currentTimeMillis()-stime)+"ms");
+		dependencies.add(0, result.dumpToTemporaryJar());
+		stime=System.currentTimeMillis();
+		Utils.executeTests(result, dependencies, testFiles.toArray(new InputFileDescriptor[] {}));
+		System.out.println("Timer: running tests: #"+(System.currentTimeMillis()-stime)+"ms");
+	}
+
+}

--- a/modules/processor-tests/src/test/java/org/springframework/slim/processor/tests/SimpleProcessorTests.java
+++ b/modules/processor-tests/src/test/java/org/springframework/slim/processor/tests/SimpleProcessorTests.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.slim.processor.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import javax.lang.model.element.Modifier;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.function.compiler.java.CompilationMessage;
+import org.springframework.cloud.function.compiler.java.CompilationResult;
+import org.springframework.cloud.function.compiler.java.DependencyResolver;
+import org.springframework.cloud.function.compiler.java.InputFileDescriptor;
+import org.springframework.core.io.FileUrlResource;
+import org.springframework.slim.processor.infra.CompilerRunner;
+
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.javapoet.TypeSpec.Builder;
+
+/**
+ * Simple tests around processor invocation.
+ * 
+ * @author Andy Clement
+ */
+public class SimpleProcessorTests {
+
+	/**
+	 * Check for an expected message that indicates the processor ran
+	 */
+	@Test
+	public void processorInvoked() {
+		CompilationResult cr = CompilerRunner.run(createType("TestClass", false));
+		// "Cannot load META-INF/slim-configuration-processor.properties (normal on first
+		// full build)"
+		assertThat(cr.getCompilationMessages()).extracting("message")
+				.anyMatch(s -> ((String) s).contains("Cannot load"));
+	}
+
+	/**
+	 * Generate a simple initializer for a class marked @Configuration
+	 */
+	@Test
+	public void springConfigurationClass() {
+		CompilationResult cr = CompilerRunner.run(createType("ConfigClass", true), getSpringDependencies());
+		List<CompilationMessage> otherMessages = cr.getCompilationMessages().stream().filter(cm -> cm.isOther())
+				.collect(Collectors.toList());
+		assertThat(otherMessages.get(1).getMessage()).isEqualTo("Found @Configuration in ConfigClass");
+		assertThat(otherMessages.get(2).getMessage()).isEqualTo("Writing Initializer ConfigClassInitializer");
+		assertThat(cr.containsNewFile("ConfigClassInitializer.class"));
+		assertThat(cr.containsNewFile("META-INF/slim-configuration-processor.properties"));
+		cr.printGeneratedSources(System.out);
+		// TODO store these in getExpectedDataDirectory() for checking ?
+		// assertThat(cr.getNewFileContents("ConfigClassInitializer.java")).isEqualTo("");
+		System.out.println(">>>>\n"+cr.getGeneratedFileContents("META-INF/slim-configuration-processor.properties"));
+	}
+	
+	@Test
+	public void incrementalBuild() throws IOException {
+		Collection<InputFileDescriptor> inputs = new ArrayList<>();
+		inputs.add(createType("ConfigClass2", true));
+		inputs.add(createType("ConfigClass", true, "ConfigClass2"));
+		CompilationResult cr = CompilerRunner.run(inputs, Collections.emptyList(), getSpringDependencies());
+		assertContainsMessage(cr, "Found @Configuration in ConfigClass");
+		assertContainsMessage(cr, "Found @Configuration in ConfigClass2");
+		assertContainsMessage(cr, "Writing Initializer ConfigClassInitializer");
+		assertContainsMessage(cr, "Writing Initializer ConfigClass2Initializer");
+		Properties p = new Properties();
+		String processorStateProperties = cr.getGeneratedFileContents("META-INF/slim-configuration-processor.properties");
+		p.load(new ByteArrayInputStream(processorStateProperties.getBytes()));
+		assertThat(p.get("import.ConfigClass")).isEqualTo("ConfigClass2");
+		cr.printGeneratedSources(System.out);
+		// ... call compiler again for just the one file ...
+		// ... check the state is loaded successfully
+		// ... check the result is the same
+	}
+	
+	// ---
+
+	private void assertContainsMessage(CompilationResult cr, String expectedMessage) {
+		boolean contains = cr.getCompilationMessages().stream().anyMatch(cm -> cm.getMessage().equals(expectedMessage));
+		if (!contains) {
+			fail("Unable to find expected message '"+expectedMessage+"' in compilation result: \n"+cr.getCompilationMessages());
+		}
+	}
+
+	public File getExpectedDataDirectory() {
+		String classname = this.getClass().getName();
+		StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+		for (int i = stack.length - 1; i >= 0; i--) {
+			if (stack[i].getClassName().equals(classname)) {
+				// First entry of our class in the stack
+				int lastdot = classname.lastIndexOf(".");
+				String simpleclassname = lastdot == -1 ? classname : classname.substring(lastdot + 1);
+				return new File("./expected_data/" + simpleclassname + "/" + stack[i].getMethodName());
+			}
+		}
+		return null;
+	}
+
+	public static File resolveJunitConsoleLauncher() {
+		DependencyResolver engine = DependencyResolver.instance();
+		Artifact junitLauncherArtifact = new DefaultArtifact(
+				"org.junit.platform:junit-platform-console-standalone:1.3.1");
+		Dependency junitLauncherDependency = new Dependency(junitLauncherArtifact, "test");
+		File file = engine.resolve(junitLauncherDependency);
+		return file;
+	}
+
+	private List<File> getSpringDependencies() {
+		try {
+			File f = new File("pom.xml");
+			DependencyResolver engine = DependencyResolver.instance();
+			List<Dependency> dependencies = engine.dependencies(new FileUrlResource(f.toURI().toURL()));
+			List<File> resolvedDependencies = dependencies.stream().map(d -> engine.resolve(d))
+					.collect(Collectors.toList());
+			return resolvedDependencies;
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	public static final ClassName IMPORT = ClassName
+			.get("org.springframework.context.annotation", "Import");
+	public static final ClassName CONFIGURATION = ClassName
+			.get("org.springframework.context.annotation", "Configuration");
+	private static TypeSpec.Builder importAnnotation(TypeSpec.Builder type, String... fullyQualifiedImports) {
+		ClassName[] array = new ClassName[fullyQualifiedImports.length];
+		for (int i=0;i<fullyQualifiedImports.length;i++) {
+			array[i] = ClassName.bestGuess(fullyQualifiedImports[i]);
+		}
+		AnnotationSpec.Builder builder = AnnotationSpec.builder(IMPORT);
+		builder.addMember("value",
+				array.length > 1 ? ("{" + typeParams(array.length) + "}") : "$T.class",
+				array);
+		return type.addAnnotation(builder.build());
+	}
+	
+	private static String typeParams(int count) {
+		StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < count; i++) {
+			if (builder.length() > 0) {
+				builder.append(", ");
+			}
+			builder.append("$T.class");
+		}
+		return builder.toString();
+	}
+
+	private static InputFileDescriptor createType(String classname, boolean markAtConfiguration, String... imports) {
+		Builder builder = TypeSpec.classBuilder(classname);
+		if (markAtConfiguration) {
+			builder.addAnnotation(CONFIGURATION);
+		}
+		if (imports.length > 0) {
+			importAnnotation(builder, imports);
+		}
+		// builder.addSuperinterface(SpringClassNames.INITIALIZER_TYPE);
+		builder.addModifiers(Modifier.PUBLIC);
+		// builder.addMethod(createInitializer());
+		TypeSpec ts = builder.build();
+		JavaFile file = JavaFile.builder("", ts).build();
+		StringBuilder sb = new StringBuilder();
+		try {
+			file.writeTo(sb);
+		} catch (IOException e) {
+			throw new IllegalStateException("Unable to write out source file: " + classname, e);
+		}
+		return new InputFileDescriptor(classname, sb.toString());
+	}
+}

--- a/modules/processor-tests/src/test/resources/logback.xml
+++ b/modules/processor-tests/src/test/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+ 
+  <root level="off">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>


### PR DESCRIPTION
Bah, I keep working on it and failing to get it in! This adds a new module that includes a few simple processor tests and in addition it includes some dynamic tests generated based on what is in module-tests and samples. The dynamic tests take a while (since we are resolving dependencies and spinning up compilers) so they do not run on unless you specify `-DgeneratedTests=true` - you can specify that via the maven command line or you can set it in the launch config in eclipse.  The value here is that you can debug the processor running inside your IDE. Add your test to module-tests or to samples as normal, then run the processor-tests (with the flag set) - you'll get a new entry for your new test in the generated tests, then can re-run that in debug mode to test compilation of your code with the processor and test execution.